### PR TITLE
feat: multi-stage Dockerfile — self-contained build from clean checkout

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,20 +1,39 @@
 # Stage 1: build
 FROM rust:1.88-slim AS builder
-RUN apt-get update && apt-get install -y pkg-config libssl-dev && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y --no-install-recommends pkg-config libssl-dev && rm -rf /var/lib/apt/lists/*
 WORKDIR /build
+
+# Copy workspace manifests and fetch dependencies early for better caching
+COPY Cargo.toml Cargo.lock ./
+COPY crates/synapse-proto/Cargo.toml crates/synapse-proto/
+COPY crates/synapse-broker/Cargo.toml crates/synapse-broker/
+COPY crates/synapse-cli/Cargo.toml crates/synapse-cli/
+RUN cargo fetch
+
+# Copy full source and build
 COPY . .
 RUN cargo build --release -p synapse-broker
 
 # Stage 2: runtime
 FROM debian:bookworm-slim
 RUN apt-get update \
- && apt-get install -y ca-certificates libssl3 postgresql-client gettext-base \
+ && apt-get install -y --no-install-recommends ca-certificates libssl3 postgresql-client gettext-base \
  && rm -rf /var/lib/apt/lists/*
+
+# Create non-root user for runtime
+RUN addgroup --system appuser && adduser --system --ingroup appuser appuser
+
 WORKDIR /app
 COPY --from=builder /build/target/release/synapse-broker /usr/local/bin/synapse-broker
 COPY --from=builder /build/webui/ /app/webui/
 COPY migrations/ /app/migrations/
 COPY entrypoint.sh /app/entrypoint.sh
 RUN chmod +x /app/entrypoint.sh
+RUN chown -R appuser:appuser /app
+
 EXPOSE 7777 7778
+HEALTHCHECK --interval=30s --timeout=10s --retries=3 --start-period=15s \
+    CMD ["bash", "-c", "echo > /dev/tcp/127.0.0.1/7777"]
+
+USER appuser
 ENTRYPOINT ["/app/entrypoint.sh"]

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,15 +1,14 @@
 #!/usr/bin/env bash
 # Synapse broker entrypoint
 # 1. Substitute env vars into config template -> /tmp/synapse-resolved.yaml
-# 2. Apply DB migration idempotently
-# 3. Exec broker
+# 2. Exec broker (sqlx applies migrations on startup)
 set -euo pipefail
 
 CONFIG_TEMPLATE="${SYNAPSE_CONFIG_TEMPLATE:-/etc/synapse/synapse.yaml}"
 CONFIG_LIVE=/tmp/synapse-resolved.yaml
 
 echo "[synapse] Resolving config from $CONFIG_TEMPLATE..."
-envsubst < "$CONFIG_TEMPLATE" > "$CONFIG_LIVE"
+envsubst '${SYNAPSE_DB_PASSWORD} ${REDIS_PASSWORD}' < "$CONFIG_TEMPLATE" > "$CONFIG_LIVE"
 
 echo "[synapse] Starting broker (sqlx applies migrations on startup)..."
 export SYNAPSE_CONFIG="$CONFIG_LIVE"


### PR DESCRIPTION
## Summary

- Replaces host-build-dependent `FROM scratch` Dockerfile with a two-stage build
- Stage 1: `rust:1.88-slim` — compiles `synapse-broker` from source (1.85 was incompatible with `home@0.5.12` dep)
- Stage 2: `debian:bookworm-slim` — minimal runtime with binary, webui assets, migrations, and entrypoint
- Adds `entrypoint.sh` — resolves config via `envsubst`, applies DB migration idempotently, execs broker
- `docker build .` now works from a clean checkout with no prior toolchain required
- Prerequisite for Gantry standalone integration (Gantry uses this repo as a remote build context)

## Test plan

- [x] `docker build -t synapse-broker:dev .` completes without error
- [x] Final image starts — entrypoint executes (fails gracefully on missing config as expected)
- [ ] CI Build & Test workflow passes

## Summary by Sourcery

Introduce a self-contained, multi-stage Docker image that builds and runs synapse-broker from a clean checkout with a dedicated runtime entrypoint.

New Features:
- Provide a two-stage Docker image that compiles synapse-broker from source and runs it on a minimal Debian-based runtime image.
- Add a container entrypoint script that resolves configuration from environment, applies database migrations, and starts the broker process.

Build:
- Change the Dockerfile from a scratch-based runtime expecting a prebuilt static binary to a multi-stage build using rust:1.88-slim and debian:bookworm-slim so images can be built without a preinstalled Rust toolchain.

Deployment:
- Bundle web UI assets, database migrations, and a config-resolving entrypoint in the runtime image to support fully self-contained container deployments.