### PR TITLE
feat(mcp): TypeScript MCP server for Synapse CLI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,5 @@ test:
 clean:
 	cargo clean
 
-.PHONY: mcp-build
 mcp-build:
 	cd mcp && npm install && npm run build

--- a/Makefile
+++ b/Makefile
@@ -18,4 +18,4 @@ clean:
 	cargo clean
 
 mcp-build:
-	cd mcp && npm install && npm run build
+	cd mcp && npm ci && npm run build

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
-.PHONY: all broker cli-linux cli-windows test clean
+.PHONY: all broker cli-linux cli-windows test clean mcp-build
 
-all: broker cli-linux cli-windows
+all: broker cli-linux cli-windows mcp-build
 
 broker:
 	cargo build --release -p synapse-broker --target x86_64-unknown-linux-musl
@@ -16,3 +16,7 @@ test:
 
 clean:
 	cargo clean
+
+.PHONY: mcp-build
+mcp-build:
+	cd mcp && npm install && npm run build

--- a/docs/plans/2026-03-02-synapse-mcp-design.md
+++ b/docs/plans/2026-03-02-synapse-mcp-design.md
@@ -104,6 +104,7 @@ Same mechanism as `synapse_listen_poll` but exits as soon as `min_messages` line
 ### `synapse_list_channels` (stub)
 
 Returns:
+
 ```json
 {
   "status": "not_implemented",

--- a/docs/plans/2026-03-02-synapse-mcp-design.md
+++ b/docs/plans/2026-03-02-synapse-mcp-design.md
@@ -130,8 +130,8 @@ Returns the same stub structure as `synapse_list_channels`.
 
 Two primitives:
 
-- **`runOnce(args, env?)`** — spawns `synapse <args>`, waits for exit, returns `{ stdout, stderr, code }`. Used by `send`.
-- **`runWithTimeout(args, timeoutMs, onLine?, env?)`** — spawns `synapse <args>`, collects stdout lines via readline. Calls `onLine(line)` on each line; if `onLine` returns `true`, the process is killed early. Kills the process after `timeoutMs` regardless. Returns collected lines. Used by `listen_poll` and `wait_for_reply`.
+- **`runOnce(args)`** — spawns `synapse <args>`, waits for exit, returns `RunResult { stdout, stderr, code }`. Used by `send`.
+- **`runWithTimeout(args, timeoutMs, earlyExit?)`** — spawns `synapse <args>`, collects stdout lines via readline. Calls `earlyExit(line, collected)` on each line; if it returns `true`, kills the process early. Returns `PollResult { messages, timedOut, exitCode, stderr }`. Used by `listen_poll` and `wait_for_reply`.
 
 ### Error Cases
 

--- a/docs/plans/2026-03-02-synapse-mcp-design.md
+++ b/docs/plans/2026-03-02-synapse-mcp-design.md
@@ -16,12 +16,12 @@ A TypeScript MCP server that wraps the `synapse` CLI binary and exposes Synapse 
 
 ### Location
 
-```
+```text
 synapse/
   mcp/
     package.json
     tsconfig.json
-plugin.json # Meridian Lex plugin manifest
+    plugin.json          # Meridian Lex plugin manifest
     <!-- IDENTITY-EXCEPTION: functional internal reference — not for public exposure -->
     install.sh           # Unix: build + symlink into ~/.claude/plugins/synapse/
     install.ps1          # Windows: build + junction into %USERPROFILE%\.claude\plugins\synapse\
@@ -67,7 +67,7 @@ Meridian Lex loads the plugin and spawns `node dist/index.js` as a child process
 ### Installation
 
 <!-- IDENTITY-EXCEPTION: functional internal reference — not for public exposure -->
-`install.sh` / `install.ps1` run `npm install && npm run build`, then symlink (Unix) or junction (Windows) `mcp/` into `~/.claude/plugins/synapse/`.
+`install.sh` / `install.ps1` run `npm ci && npm run build`, then symlink (Unix) or junction (Windows) `mcp/` into `~/.claude/plugins/synapse/`.
 
 ---
 
@@ -155,7 +155,7 @@ No runtime test suite. Correctness is verified via manual smoke tests documented
 3. `synapse_listen_poll` on an active channel — confirm message array returned
 4. `synapse_wait_for_reply` — send from a second agent, confirm early exit
 
-Future: `make mcp-build` target in the Synapse `Makefile`.
+The Synapse Makefile includes a `mcp-build` target (`make mcp-build`) to build the MCP server from the repo root.
 
 ---
 

--- a/docs/plans/2026-03-02-synapse-mcp-design.md
+++ b/docs/plans/2026-03-02-synapse-mcp-design.md
@@ -1,0 +1,169 @@
+# Synapse MCP Integration — Design
+
+**Date:** 2026-03-02
+**Status:** Approved
+**Author:** Meridian Lex
+
+---
+
+## Overview
+
+A TypeScript MCP server that wraps the `synapse` CLI binary and exposes Synapse fleet communications as native MCP tools within Meridian Lex. Co-located in the Synapse monorepo at `synapse/mcp/`. Packaged as a Meridian Lex plugin installable via `install.sh` / `install.ps1`.
+
+---
+
+## Architecture
+
+### Location
+
+```
+synapse/
+  mcp/
+    package.json
+    tsconfig.json
+plugin.json # Meridian Lex plugin manifest
+    <!-- IDENTITY-EXCEPTION: functional internal reference — not for public exposure -->
+    install.sh           # Unix: build + symlink into ~/.claude/plugins/synapse/
+    install.ps1          # Windows: build + junction into %USERPROFILE%\.claude\plugins\synapse\
+    src/
+      index.ts           # MCP server entry point, tool registration
+      cli.ts             # Shared CLI spawner — env, process management
+      tools/
+        send.ts          # synapse_send_message
+        listen.ts        # synapse_listen_poll, synapse_wait_for_reply
+        stubs.ts         # synapse_list_channels, synapse_get_channel_history
+    dist/                # Compiled output (gitignored)
+    README.md
+```
+
+### Runtime Flow
+
+Meridian Lex loads the plugin and spawns `node dist/index.js` as a child process. Communication is via stdin/stdout using MCP JSON-RPC (stdio transport). When a tool is called, the MCP server spawns a `synapse` CLI sub-process. Credentials are inherited from the environment via `SYNAPSE_*` variables. The CLI binary path defaults to `synapse` in PATH and is overridable via `SYNAPSE_CLI`.
+
+### Plugin Manifest (`plugin.json`)
+
+```json
+{
+  "name": "synapse",
+  "version": "0.1.0",
+  "description": "Synapse fleet communications MCP tools",
+  "mcpServers": {
+    "synapse": {
+      "command": "node",
+      <!-- IDENTITY-EXCEPTION: functional internal reference — not for public exposure -->
+      "args": ["${CLAUDE_PLUGIN_ROOT}/dist/index.js"],
+      "env": {
+        "SYNAPSE_HOST":   "${SYNAPSE_HOST}",
+        "SYNAPSE_CA":     "${SYNAPSE_CA}",
+        "SYNAPSE_AGENT":  "${SYNAPSE_AGENT}",
+        "SYNAPSE_SECRET": "${SYNAPSE_SECRET}",
+        "SYNAPSE_CLI":    "${SYNAPSE_CLI}"
+      }
+    }
+  }
+}
+```
+
+### Installation
+
+<!-- IDENTITY-EXCEPTION: functional internal reference — not for public exposure -->
+`install.sh` / `install.ps1` run `npm install && npm run build`, then symlink (Unix) or junction (Windows) `mcp/` into `~/.claude/plugins/synapse/`.
+
+---
+
+## Tools
+
+### `synapse_send_message`
+
+| Argument | Type | Default | Description |
+|----------|------|---------|-------------|
+| `channel` | string | — | Channel name, e.g. `#general` |
+| `message` | string | — | Message body |
+
+Spawns `synapse send --channel <channel> <message>`. Returns `"Delivered."` on success or a structured error on non-zero exit.
+
+### `synapse_listen_poll`
+
+| Argument | Type | Default | Description |
+|----------|------|---------|-------------|
+| `channel` | string | — | Channel to listen on |
+| `timeout_seconds` | number | 5 | How long to collect messages before returning |
+
+Spawns `synapse listen --channel <channel>`, collects stdout lines via readline for `timeout_seconds`, then SIGTERMs the process. Returns an array of message strings. Empty array is a valid (not error) response — the channel may be quiet.
+
+### `synapse_wait_for_reply`
+
+| Argument | Type | Default | Description |
+|----------|------|---------|-------------|
+| `channel` | string | — | Channel to watch |
+| `timeout_seconds` | number | 30 | Maximum wait time |
+| `min_messages` | number | 1 | Exit early once this many messages are received |
+
+Same mechanism as `synapse_listen_poll` but exits as soon as `min_messages` lines arrive, before the timeout. Designed for conversation loops: Lex sends a message, calls `synapse_wait_for_reply`, receives the response. Returns `{ timedOut: boolean, messages: string[] }` so callers can distinguish a reply from a timeout.
+
+### `synapse_list_channels` (stub)
+
+Returns:
+```json
+{
+  "status": "not_implemented",
+  "capability": "synapse_list_channels",
+  "action_required": "Check TASK-QUEUE.md for a task covering this capability. If none exists, create one. If capacity is free, resolve it now."
+}
+```
+
+### `synapse_get_channel_history` (stub)
+
+| Argument | Type | Default | Description |
+|----------|------|---------|-------------|
+| `channel` | string | — | Channel to fetch history for |
+| `limit` | number | 50 | Max messages to return |
+
+Returns the same stub structure as `synapse_list_channels`.
+
+---
+
+## Data Flow and Error Handling
+
+### `cli.ts` — Shared Spawner
+
+Two primitives:
+
+- **`runOnce(args, env?)`** — spawns `synapse <args>`, waits for exit, returns `{ stdout, stderr, code }`. Used by `send`.
+- **`runWithTimeout(args, timeoutMs, onLine?, env?)`** — spawns `synapse <args>`, collects stdout lines via readline. Calls `onLine(line)` on each line; if `onLine` returns `true`, the process is killed early. Kills the process after `timeoutMs` regardless. Returns collected lines. Used by `listen_poll` and `wait_for_reply`.
+
+### Error Cases
+
+| Condition | Response |
+|-----------|----------|
+| CLI binary not found | `"synapse CLI not found. Set SYNAPSE_CLI or add synapse to PATH. See mcp/README.md or run mcp/install.sh."` |
+| Missing `SYNAPSE_*` credentials | Early validation before spawn; lists which variables are unset |
+| Non-zero exit from `synapse send` | Return stderr as tool error |
+| Listen timeout, zero messages | Return empty array — not an error |
+| `wait_for_reply` timeout | Return `{ timedOut: true, messages: [] }` |
+
+---
+
+## Build
+
+`package.json` `build` script runs `tsc --noEmit` (type check) then `tsc` (emit). Output to `dist/`. TypeScript strict mode enabled.
+
+No runtime test suite. Correctness is verified via manual smoke tests documented in `mcp/README.md`:
+
+1. Send raw MCP JSON to `node dist/index.js` via stdin to verify tool discovery
+2. `synapse_send_message` against a live broker — confirm `"Delivered."`
+3. `synapse_listen_poll` on an active channel — confirm message array returned
+4. `synapse_wait_for_reply` — send from a second agent, confirm early exit
+
+Future: `make mcp-build` target in the Synapse `Makefile`.
+
+---
+
+## Dependencies
+
+| Package | Purpose |
+|---------|---------|
+| `@modelcontextprotocol/sdk` | MCP stdio server, tool registration, JSON-RPC |
+| `zod` | Tool argument validation |
+| `typescript` | Build toolchain (dev dependency) |
+| `@types/node` | Node type definitions (dev dependency) |

--- a/docs/plans/2026-03-02-synapse-mcp.md
+++ b/docs/plans/2026-03-02-synapse-mcp.md
@@ -63,7 +63,7 @@
 
 **Step 3: Create `mcp/.gitignore`**
 
-```
+```text
 dist/
 node_modules/
 ```
@@ -815,10 +815,11 @@ echo '...tools/call synapse_listen_poll {"channel":"#general","timeout_seconds":
 
 Expected: JSON array containing the message sent.
 
-### 4. Wait for reply
+### 4. Wait for a reply
 
 Call `synapse_wait_for_reply` with `timeout_seconds: 10`, then send a message
 from another agent. Expected: early exit with `{ timedOut: false, messages: [...] }`.
+
 ```
 
 **Step 2: Commit**

--- a/docs/plans/2026-03-02-synapse-mcp.md
+++ b/docs/plans/2026-03-02-synapse-mcp.md
@@ -581,7 +581,6 @@ git commit -m "feat(mcp): add MCP server entry point with all tool registrations
   "mcpServers": {
     "synapse": {
       "command": "node",
-      
       <!-- IDENTITY-EXCEPTION: functional internal reference — not for public exposure -->
       "args": ["${CLAUDE_PLUGIN_ROOT}/dist/index.js"],
       "env": {
@@ -618,7 +617,6 @@ git commit -m "feat(mcp): add plugin manifest"
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-
 <!-- IDENTITY-EXCEPTION: functional internal reference — not for public exposure -->
 PLUGIN_DIR="${HOME}/.claude/plugins/synapse"
 
@@ -641,7 +639,6 @@ fi
 ln -s "$SCRIPT_DIR" "$PLUGIN_DIR"
 echo "Done. Plugin installed at ${PLUGIN_DIR} -> ${SCRIPT_DIR}"
 echo ""
-
 <!-- IDENTITY-EXCEPTION: functional internal reference — not for public exposure -->
 echo "Required environment variables (set in your shell or ~/.claude/settings.json):"
 echo "  SYNAPSE_AGENT   — your agent name"
@@ -743,7 +740,6 @@ cd mcp
 ```
 
 The script builds the TypeScript project and symlinks (Unix) or junctions (Windows)
-
 <!-- IDENTITY-EXCEPTION: functional internal reference — not for public exposure -->
 `mcp/` into `~/.claude/plugins/synapse/`.
 
@@ -764,7 +760,6 @@ $env:SYNAPSE_CLI = "C:\path\to\synapse.exe"
 ## Configuration
 
 Set these environment variables before starting a session (or add to
-
 <!-- IDENTITY-EXCEPTION: functional internal reference — not for public exposure -->
 `~/.claude/settings.json` under `env`):
 

--- a/docs/plans/2026-03-02-synapse-mcp.md
+++ b/docs/plans/2026-03-02-synapse-mcp.md
@@ -820,8 +820,6 @@ Expected: JSON array containing the message sent.
 Call `synapse_wait_for_reply` with `timeout_seconds: 10`, then send a message
 from another agent. Expected: early exit with `{ timedOut: false, messages: [...] }`.
 
-```
-
 **Step 2: Commit**
 
 ```bash
@@ -855,11 +853,13 @@ mcp-build:
 **Step 3: Add `mcp-build` to the `all` target**
 
 Find the line:
+
 ```makefile
 all: broker cli-linux cli-windows
 ```
 
 Change to:
+
 ```makefile
 all: broker cli-linux cli-windows mcp-build
 ```

--- a/docs/plans/2026-03-02-synapse-mcp.md
+++ b/docs/plans/2026-03-02-synapse-mcp.md
@@ -1,0 +1,903 @@
+# Synapse MCP Server Implementation Plan
+
+> **For Lex:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Build a TypeScript MCP server in `synapse/mcp/` that wraps the `synapse` CLI binary and exposes fleet communications as MCP tools usable natively in Meridian Lex sessions.
+
+**Architecture:** stdio MCP server using `@modelcontextprotocol/sdk`. CLI calls are spawned as child processes. All credential configuration flows through `SYNAPSE_*` environment variables. Packaged as a plugin with `install.sh` / `install.ps1`.
+
+**Tech Stack:** TypeScript 5, `@modelcontextprotocol/sdk`, `zod`, Node.js `child_process` + `readline`.
+
+---
+
+## Task 1: Scaffold project structure
+
+**Files:**
+- Create: `mcp/package.json`
+- Create: `mcp/tsconfig.json`
+- Create: `mcp/.gitignore`
+
+**Step 1: Create `mcp/package.json`**
+
+```json
+{
+  "name": "synapse-mcp",
+  "version": "0.1.0",
+  "description": "Synapse fleet communications MCP server",
+  "type": "module",
+  "main": "dist/index.js",
+  "scripts": {
+    "build": "tsc --noEmit && tsc",
+    "dev": "tsc --watch"
+  },
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.0.0",
+    "zod": "^3.22.0"
+  },
+  "devDependencies": {
+    "typescript": "^5.3.0",
+    "@types/node": "^20.0.0"
+  }
+}
+```
+
+**Step 2: Create `mcp/tsconfig.json`**
+
+```json
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "Node16",
+    "moduleResolution": "Node16",
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "declaration": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["dist", "node_modules"]
+}
+```
+
+**Step 3: Create `mcp/.gitignore`**
+
+```
+dist/
+node_modules/
+```
+
+**Step 4: Commit**
+
+```bash
+cd synapse/mcp
+git add package.json tsconfig.json .gitignore
+git commit -m "chore(mcp): scaffold TypeScript MCP project"
+```
+
+---
+
+## Task 2: Write `src/cli.ts` — shared CLI spawner
+
+**Files:**
+- Create: `mcp/src/cli.ts`
+
+This module is the only place in the codebase that touches `child_process`. All tools import from here. It validates credentials before spawning anything.
+
+**Step 1: Create `mcp/src/cli.ts`**
+
+```typescript
+import { spawn } from "child_process";
+import { createInterface } from "readline";
+
+export interface RunResult {
+  stdout: string;
+  stderr: string;
+  code: number;
+}
+
+export interface PollResult {
+  messages: string[];
+  timedOut: boolean;
+}
+
+/** Resolve synapse binary path. SYNAPSE_CLI overrides; falls back to "synapse" in PATH. */
+function resolveBin(): string {
+  return process.env.SYNAPSE_CLI ?? "synapse";
+}
+
+/** Build child process env — passes all SYNAPSE_* vars through. */
+function buildEnv(): NodeJS.ProcessEnv {
+  return { ...process.env };
+}
+
+/** Returns an error string if required SYNAPSE_* vars are missing, else null. */
+export function validateCredentials(): string | null {
+  const required = ["SYNAPSE_AGENT", "SYNAPSE_SECRET"];
+  const missing = required.filter((k) => !process.env[k]);
+  if (missing.length === 0) return null;
+  return `Missing required environment variables: ${missing.join(", ")}. Set them before starting the MCP server.`;
+}
+
+/**
+ * Spawn synapse with the given args, wait for exit.
+ * Used by send_message.
+ */
+export async function runOnce(args: string[]): Promise<RunResult> {
+  const bin = resolveBin();
+  return new Promise((resolve, reject) => {
+    const child = spawn(bin, args, {
+      env: buildEnv(),
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+
+    let stdout = "";
+    let stderr = "";
+
+    child.stdout.on("data", (d: Buffer) => { stdout += d.toString(); });
+    child.stderr.on("data", (d: Buffer) => { stderr += d.toString(); });
+
+    child.on("error", (err: NodeJS.ErrnoException) => {
+      if (err.code === "ENOENT") {
+        reject(new Error(
+          `synapse CLI not found. Set SYNAPSE_CLI or add synapse to PATH. ` +
+          `See mcp/README.md or run mcp/install.sh to set up the Synapse CLI.`
+        ));
+      } else {
+        reject(err);
+      }
+    });
+
+    child.on("close", (code: number | null) => {
+      resolve({ stdout: stdout.trim(), stderr: stderr.trim(), code: code ?? 1 });
+    });
+  });
+}
+
+/**
+ * Spawn synapse with the given args, collect stdout lines for timeoutMs.
+ * onLine is called for each line; return true to exit early (e.g. enough messages received).
+ * Used by listen_poll and wait_for_reply.
+ */
+export async function runWithTimeout(
+  args: string[],
+  timeoutMs: number,
+  onLine?: (line: string, collected: string[]) => boolean
+): Promise<PollResult> {
+  const bin = resolveBin();
+  return new Promise((resolve, reject) => {
+    const child = spawn(bin, args, {
+      env: buildEnv(),
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+
+    const messages: string[] = [];
+    let settled = false;
+
+    child.on("error", (err: NodeJS.ErrnoException) => {
+      if (err.code === "ENOENT") {
+        reject(new Error(
+          `synapse CLI not found. Set SYNAPSE_CLI or add synapse to PATH. ` +
+          `See mcp/README.md or run mcp/install.sh to set up the Synapse CLI.`
+        ));
+      } else {
+        reject(err);
+      }
+    });
+
+    const rl = createInterface({ input: child.stdout, crlfDelay: Infinity });
+
+    rl.on("line", (line: string) => {
+      // Filter the initial status line from `synapse listen`
+      if (line.startsWith("Listening on ")) return;
+      if (line === "") return;
+      messages.push(line);
+      if (!settled && onLine && onLine(line, messages)) {
+        settled = true;
+        clearTimeout(timer);
+        child.kill("SIGTERM");
+        resolve({ messages, timedOut: false });
+      }
+    });
+
+    const timer = setTimeout(() => {
+      if (!settled) {
+        settled = true;
+        child.kill("SIGTERM");
+        resolve({ messages, timedOut: true });
+      }
+    }, timeoutMs);
+
+    child.on("close", () => {
+      if (!settled) {
+        settled = true;
+        clearTimeout(timer);
+        resolve({ messages, timedOut: false });
+      }
+    });
+  });
+}
+```
+
+**Step 2: Verify it compiles**
+
+```bash
+cd synapse/mcp
+npm install
+npx tsc --noEmit
+```
+
+Expected: no errors (only missing src files — that is fine at this stage, we're building incrementally).
+
+**Step 3: Commit**
+
+```bash
+git add src/cli.ts
+git commit -m "feat(mcp): add CLI spawner with runOnce and runWithTimeout"
+```
+
+---
+
+## Task 3: Write `src/tools/send.ts`
+
+**Files:**
+- Create: `mcp/src/tools/send.ts`
+
+**Step 1: Create `mcp/src/tools/send.ts`**
+
+```typescript
+import { z } from "zod";
+import { runOnce, validateCredentials } from "../cli.js";
+
+export const SendMessageSchema = z.object({
+  channel: z.string().describe("Channel name, e.g. #general"),
+  message: z.string().describe("Message body to send"),
+});
+
+export const sendMessageTool = {
+  name: "synapse_send_message",
+  description: "Send a message to a Synapse fleet channel.",
+  inputSchema: {
+    type: "object" as const,
+    properties: {
+      channel: { type: "string", description: "Channel name, e.g. #general" },
+      message: { type: "string", description: "Message body to send" },
+    },
+    required: ["channel", "message"],
+  },
+};
+
+export async function handleSendMessage(args: unknown): Promise<string> {
+  const credErr = validateCredentials();
+  if (credErr) return credErr;
+
+  const { channel, message } = SendMessageSchema.parse(args);
+  const result = await runOnce(["send", "--channel", channel, message]);
+
+  if (result.code !== 0) {
+    return `Send failed (exit ${result.code}): ${result.stderr || result.stdout || "unknown error"}`;
+  }
+
+  return result.stdout || "Delivered.";
+}
+```
+
+**Step 2: Verify compiles**
+
+```bash
+npx tsc --noEmit
+```
+
+**Step 3: Commit**
+
+```bash
+git add src/tools/send.ts
+git commit -m "feat(mcp): add synapse_send_message tool"
+```
+
+---
+
+## Task 4: Write `src/tools/listen.ts`
+
+**Files:**
+- Create: `mcp/src/tools/listen.ts`
+
+**Step 1: Create `mcp/src/tools/listen.ts`**
+
+```typescript
+import { z } from "zod";
+import { runWithTimeout, validateCredentials } from "../cli.js";
+
+export const ListenPollSchema = z.object({
+  channel: z.string().describe("Channel name, e.g. #general"),
+  timeout_seconds: z.number().int().min(1).max(120).default(5)
+    .describe("How long to collect messages before returning (default 5s)"),
+});
+
+export const WaitForReplySchema = z.object({
+  channel: z.string().describe("Channel name, e.g. #general"),
+  timeout_seconds: z.number().int().min(1).max(300).default(30)
+    .describe("Maximum time to wait for replies (default 30s)"),
+  min_messages: z.number().int().min(1).default(1)
+    .describe("Exit early once this many messages are received (default 1)"),
+});
+
+export const listenPollTool = {
+  name: "synapse_listen_poll",
+  description:
+    "Poll a Synapse channel for messages. Listens for timeout_seconds and returns all messages received. " +
+    "Empty array means the channel was quiet — not an error.",
+  inputSchema: {
+    type: "object" as const,
+    properties: {
+      channel: { type: "string", description: "Channel name, e.g. #general" },
+      timeout_seconds: {
+        type: "number",
+        description: "How long to collect messages (default 5s, max 120s)",
+        default: 5,
+      },
+    },
+    required: ["channel"],
+  },
+};
+
+export const waitForReplyTool = {
+  name: "synapse_wait_for_reply",
+  description:
+    "Wait for a reply on a Synapse channel. Exits as soon as min_messages arrive or timeout_seconds elapses. " +
+    "Use after synapse_send_message to receive the response in a conversation loop. " +
+    "Returns { timedOut, messages }.",
+  inputSchema: {
+    type: "object" as const,
+    properties: {
+      channel: { type: "string", description: "Channel name, e.g. #general" },
+      timeout_seconds: {
+        type: "number",
+        description: "Maximum wait time in seconds (default 30s, max 300s)",
+        default: 30,
+      },
+      min_messages: {
+        type: "number",
+        description: "Exit early once this many messages are received (default 1)",
+        default: 1,
+      },
+    },
+    required: ["channel"],
+  },
+};
+
+export async function handleListenPoll(args: unknown): Promise<string> {
+  const credErr = validateCredentials();
+  if (credErr) return credErr;
+
+  const { channel, timeout_seconds } = ListenPollSchema.parse(args);
+  const result = await runWithTimeout(
+    ["listen", "--channel", channel],
+    timeout_seconds * 1000
+  );
+
+  return JSON.stringify(result.messages);
+}
+
+export async function handleWaitForReply(args: unknown): Promise<string> {
+  const credErr = validateCredentials();
+  if (credErr) return credErr;
+
+  const { channel, timeout_seconds, min_messages } = WaitForReplySchema.parse(args);
+  const result = await runWithTimeout(
+    ["listen", "--channel", channel],
+    timeout_seconds * 1000,
+    (_line, collected) => collected.length >= min_messages
+  );
+
+  return JSON.stringify({ timedOut: result.timedOut, messages: result.messages });
+}
+```
+
+**Step 2: Verify compiles**
+
+```bash
+npx tsc --noEmit
+```
+
+**Step 3: Commit**
+
+```bash
+git add src/tools/listen.ts
+git commit -m "feat(mcp): add synapse_listen_poll and synapse_wait_for_reply tools"
+```
+
+---
+
+## Task 5: Write `src/tools/stubs.ts`
+
+**Files:**
+- Create: `mcp/src/tools/stubs.ts`
+
+**Step 1: Create `mcp/src/tools/stubs.ts`**
+
+```typescript
+import { z } from "zod";
+
+const STUB_ACTION =
+  "Check TASK-QUEUE.md for a task covering this capability. " +
+  "If none exists, create one. If capacity is free, resolve it now.";
+
+function stubResponse(capability: string): string {
+  return JSON.stringify({
+    status: "not_implemented",
+    capability,
+    action_required: STUB_ACTION,
+  });
+}
+
+export const listChannelsTool = {
+  name: "synapse_list_channels",
+  description:
+    "List available Synapse channels. NOT YET IMPLEMENTED — returns a task-queue reminder.",
+  inputSchema: {
+    type: "object" as const,
+    properties: {},
+    required: [],
+  },
+};
+
+export const getChannelHistoryTool = {
+  name: "synapse_get_channel_history",
+  description:
+    "Fetch message history from a Synapse channel. NOT YET IMPLEMENTED — returns a task-queue reminder.",
+  inputSchema: {
+    type: "object" as const,
+    properties: {
+      channel: { type: "string", description: "Channel name, e.g. #general" },
+      limit: { type: "number", description: "Max messages to return (default 50)", default: 50 },
+    },
+    required: ["channel"],
+  },
+};
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+export async function handleListChannels(_args: unknown): Promise<string> {
+  return stubResponse("synapse_list_channels");
+}
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+export async function handleGetChannelHistory(_args: unknown): Promise<string> {
+  return stubResponse("synapse_get_channel_history");
+}
+```
+
+**Step 2: Verify compiles**
+
+```bash
+npx tsc --noEmit
+```
+
+**Step 3: Commit**
+
+```bash
+git add src/tools/stubs.ts
+git commit -m "feat(mcp): add stub tools with task-queue reminders"
+```
+
+---
+
+## Task 6: Write `src/index.ts` — MCP server entry point
+
+**Files:**
+- Create: `mcp/src/index.ts`
+
+**Step 1: Create `mcp/src/index.ts`**
+
+```typescript
+import { Server } from "@modelcontextprotocol/sdk/server/index.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import {
+  CallToolRequestSchema,
+  ListToolsRequestSchema,
+} from "@modelcontextprotocol/sdk/types.js";
+
+import { sendMessageTool, handleSendMessage } from "./tools/send.js";
+import { listenPollTool, waitForReplyTool, handleListenPoll, handleWaitForReply } from "./tools/listen.js";
+import { listChannelsTool, getChannelHistoryTool, handleListChannels, handleGetChannelHistory } from "./tools/stubs.js";
+
+const server = new Server(
+  { name: "synapse", version: "0.1.0" },
+  { capabilities: { tools: {} } }
+);
+
+const tools = [
+  sendMessageTool,
+  listenPollTool,
+  waitForReplyTool,
+  listChannelsTool,
+  getChannelHistoryTool,
+];
+
+server.setRequestHandler(ListToolsRequestSchema, async () => ({ tools }));
+
+server.setRequestHandler(CallToolRequestSchema, async (request) => {
+  const { name, arguments: args } = request.params;
+
+  let text: string;
+  try {
+    switch (name) {
+      case "synapse_send_message":       text = await handleSendMessage(args); break;
+      case "synapse_listen_poll":        text = await handleListenPoll(args); break;
+      case "synapse_wait_for_reply":     text = await handleWaitForReply(args); break;
+      case "synapse_list_channels":      text = await handleListChannels(args); break;
+      case "synapse_get_channel_history": text = await handleGetChannelHistory(args); break;
+      default:
+        return {
+          content: [{ type: "text" as const, text: `Unknown tool: ${name}` }],
+          isError: true,
+        };
+    }
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return {
+      content: [{ type: "text" as const, text: `Tool error: ${message}` }],
+      isError: true,
+    };
+  }
+
+  return { content: [{ type: "text" as const, text }] };
+});
+
+const transport = new StdioServerTransport();
+await server.connect(transport);
+```
+
+**Step 2: Build**
+
+```bash
+npm run build
+```
+
+Expected: `dist/index.js` and supporting files created, no TypeScript errors.
+
+**Step 3: Commit**
+
+```bash
+git add src/index.ts
+git commit -m "feat(mcp): add MCP server entry point with all tool registrations"
+```
+
+---
+
+## Task 7: Write `plugin.json`
+
+**Files:**
+- Create: `mcp/plugin.json`
+
+**Step 1: Create `mcp/plugin.json`**
+
+```json
+{
+  "name": "synapse",
+  "version": "0.1.0",
+  "description": "Synapse fleet communications MCP tools — send, listen, poll channels",
+  "mcpServers": {
+    "synapse": {
+      "command": "node",
+      <!-- IDENTITY-EXCEPTION: functional internal reference — not for public exposure -->
+      "args": ["${CLAUDE_PLUGIN_ROOT}/dist/index.js"],
+      "env": {
+        "SYNAPSE_HOST":   "${SYNAPSE_HOST}",
+        "SYNAPSE_CA":     "${SYNAPSE_CA}",
+        "SYNAPSE_AGENT":  "${SYNAPSE_AGENT}",
+        "SYNAPSE_SECRET": "${SYNAPSE_SECRET}",
+        "SYNAPSE_CLI":    "${SYNAPSE_CLI}"
+      }
+    }
+  }
+}
+```
+
+**Step 2: Commit**
+
+```bash
+git add plugin.json
+git commit -m "feat(mcp): add plugin manifest"
+```
+
+---
+
+## Task 8: Write `install.sh` and `install.ps1`
+
+**Files:**
+- Create: `mcp/install.sh`
+- Create: `mcp/install.ps1`
+
+**Step 1: Create `mcp/install.sh`**
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+<!-- IDENTITY-EXCEPTION: functional internal reference — not for public exposure -->
+PLUGIN_DIR="${HOME}/.claude/plugins/synapse"
+
+echo "Building synapse-mcp..."
+cd "$SCRIPT_DIR"
+npm install
+npm run build
+
+echo "Installing plugin to ${PLUGIN_DIR}..."
+mkdir -p "$(dirname "$PLUGIN_DIR")"
+
+if [ -L "$PLUGIN_DIR" ]; then
+  echo "Removing existing symlink at ${PLUGIN_DIR}"
+  rm "$PLUGIN_DIR"
+elif [ -d "$PLUGIN_DIR" ]; then
+  echo "ERROR: ${PLUGIN_DIR} exists and is not a symlink. Remove it manually before installing."
+  exit 1
+fi
+
+ln -s "$SCRIPT_DIR" "$PLUGIN_DIR"
+echo "Done. Plugin installed at ${PLUGIN_DIR} -> ${SCRIPT_DIR}"
+echo ""
+<!-- IDENTITY-EXCEPTION: functional internal reference — not for public exposure -->
+echo "Required environment variables (set in your shell or ~/.claude/settings.json):"
+echo "  SYNAPSE_AGENT   — your agent name"
+echo "  SYNAPSE_SECRET  — your agent secret"
+echo "  SYNAPSE_HOST    — broker address (default: localhost:7777)"
+echo "  SYNAPSE_CA      — CA cert path (default: /etc/synapse/ca.pem)"
+echo "  SYNAPSE_CLI     — path to synapse binary (default: synapse in PATH)"
+```
+
+**Step 2: Make executable**
+
+```bash
+chmod +x install.sh
+```
+
+**Step 3: Create `mcp/install.ps1`**
+
+```powershell
+#Requires -Version 5.1
+$ErrorActionPreference = "Stop"
+
+$ScriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+$PluginDir = Join-Path $env:USERPROFILE ".claude\plugins\synapse"
+
+Write-Host "Building synapse-mcp..."
+Set-Location $ScriptDir
+npm install
+npm run build
+
+Write-Host "Installing plugin to $PluginDir ..."
+$PluginsParent = Split-Path -Parent $PluginDir
+if (-not (Test-Path $PluginsParent)) {
+    New-Item -ItemType Directory -Path $PluginsParent | Out-Null
+}
+
+if (Test-Path $PluginDir) {
+    $item = Get-Item $PluginDir
+    if ($item.Attributes -band [System.IO.FileAttributes]::ReparsePoint) {
+        Write-Host "Removing existing junction at $PluginDir"
+        Remove-Item $PluginDir -Force
+    } else {
+        Write-Error "ERROR: $PluginDir exists and is not a junction. Remove it manually before installing."
+        exit 1
+    }
+}
+
+cmd /c "mklink /J `"$PluginDir`" `"$ScriptDir`"" | Out-Null
+Write-Host "Done. Plugin installed at $PluginDir -> $ScriptDir"
+Write-Host ""
+Write-Host "Required environment variables:"
+Write-Host "  SYNAPSE_AGENT   -- your agent name"
+Write-Host "  SYNAPSE_SECRET  -- your agent secret"
+Write-Host "  SYNAPSE_HOST    -- broker address (default: localhost:7777)"
+Write-Host "  SYNAPSE_CA      -- CA cert path (default: /etc/synapse/ca.pem)"
+Write-Host "  SYNAPSE_CLI     -- path to synapse binary (default: synapse in PATH)"
+```
+
+**Step 4: Commit**
+
+```bash
+git add install.sh install.ps1
+git commit -m "feat(mcp): add install scripts for Unix and Windows"
+```
+
+---
+
+## Task 9: Write `README.md`
+
+**Files:**
+- Create: `mcp/README.md`
+
+**Step 1: Create `mcp/README.md`**
+
+```markdown
+# synapse-mcp
+
+TypeScript MCP server for Synapse fleet communications. Wraps the `synapse` CLI
+binary and exposes fleet channels as native MCP tools.
+
+## Requirements
+
+- Node.js 18+
+- The `synapse` CLI binary (from `make cli-linux` in the Synapse repo root, or the pre-built release)
+
+## Installation
+
+### Unix
+
+```bash
+cd mcp
+./install.sh
+```
+
+### Windows
+
+```powershell
+cd mcp
+.\install.ps1
+```
+
+The script builds the TypeScript project and symlinks (Unix) or junctions (Windows)
+<!-- IDENTITY-EXCEPTION: functional internal reference — not for public exposure -->
+`mcp/` into `~/.claude/plugins/synapse/`.
+
+### Manual binary setup
+
+If `synapse` is not in your PATH, set:
+
+```bash
+export SYNAPSE_CLI=/path/to/synapse
+```
+
+Or on Windows:
+
+```powershell
+$env:SYNAPSE_CLI = "C:\path\to\synapse.exe"
+```
+
+## Configuration
+
+Set these environment variables before starting a session (or add to
+<!-- IDENTITY-EXCEPTION: functional internal reference — not for public exposure -->
+`~/.claude/settings.json` under `env`):
+
+| Variable | Required | Default | Description |
+|----------|----------|---------|-------------|
+| `SYNAPSE_AGENT` | Yes | — | Your agent name |
+| `SYNAPSE_SECRET` | Yes | — | Your agent secret |
+| `SYNAPSE_HOST` | No | `localhost:7777` | Broker address |
+| `SYNAPSE_CA` | No | `/etc/synapse/ca.pem` | CA certificate path |
+| `SYNAPSE_CLI` | No | `synapse` (PATH) | Path to synapse binary |
+
+## Tools
+
+| Tool | Description |
+|------|-------------|
+| `synapse_send_message` | Send a message to a channel |
+| `synapse_listen_poll` | Poll a channel for N seconds, return all messages |
+| `synapse_wait_for_reply` | Wait for a reply with early-exit on first message |
+| `synapse_list_channels` | Stub — creates a task-queue reminder |
+| `synapse_get_channel_history` | Stub — creates a task-queue reminder |
+
+## Smoke Tests
+
+Run these manually after installation to verify the integration.
+
+### 1. Tool discovery
+
+```bash
+echo '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"test","version":"0.0.1"}}}
+{"jsonrpc":"2.0","id":2,"method":"tools/list","params":{}}' \
+  | SYNAPSE_AGENT=test SYNAPSE_SECRET=test node dist/index.js
+```
+
+Expected: JSON response listing all 5 tools.
+
+### 2. Send a message
+
+```bash
+SYNAPSE_AGENT=my-agent SYNAPSE_SECRET=my-secret \
+  SYNAPSE_HOST=synapse.example.com:7777 \
+  SYNAPSE_CA=/etc/synapse/ca.pem \
+  synapse send --channel '#general' "test from mcp smoke"
+```
+
+### 3. Poll a channel
+
+Send a message on a second terminal, then on the first:
+
+```bash
+echo '...tools/call synapse_listen_poll {"channel":"#general","timeout_seconds":5}...' \
+  | node dist/index.js
+```
+
+Expected: JSON array containing the message sent.
+
+### 4. Wait for reply
+
+Call `synapse_wait_for_reply` with `timeout_seconds: 10`, then send a message
+from another agent. Expected: early exit with `{ timedOut: false, messages: [...] }`.
+```
+
+**Step 2: Commit**
+
+```bash
+git add README.md
+git commit -m "docs(mcp): add README with setup, config, and smoke test instructions"
+```
+
+---
+
+## Task 10: Wire `mcp-build` into the Synapse Makefile
+
+**Files:**
+- Modify: `Makefile` (Synapse repo root)
+
+**Step 1: Read the current Makefile targets**
+
+```bash
+grep -n "^[a-z]" Makefile | head -20
+```
+
+**Step 2: Add `mcp-build` target**
+
+Append after the existing `test` target (or at the end of the file):
+
+```makefile
+.PHONY: mcp-build
+mcp-build:
+	cd mcp && npm install && npm run build
+```
+
+**Step 3: Add `mcp-build` to the `all` target**
+
+Find the line:
+```makefile
+all: broker cli-linux cli-windows
+```
+
+Change to:
+```makefile
+all: broker cli-linux cli-windows mcp-build
+```
+
+**Step 4: Commit**
+
+```bash
+git add Makefile
+git commit -m "chore: add mcp-build target to Makefile"
+```
+
+---
+
+## Task 11: Final build verification and push
+
+**Step 1: Clean build from scratch**
+
+```bash
+cd mcp
+rm -rf dist node_modules
+npm install
+npm run build
+```
+
+Expected: `dist/index.js` exists, no TypeScript errors.
+
+**Step 2: Verify tool listing works**
+
+```bash
+printf '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"test","version":"0.0.1"}}}\n{"jsonrpc":"2.0","id":2,"method":"tools/list","params":{}}\n' \
+  | SYNAPSE_AGENT=test SYNAPSE_SECRET=test node dist/index.js 2>/dev/null
+```
+
+Expected: response contains all 5 tool names.
+
+**Step 3: Push branch**
+
+```bash
+git push origin fix/broker-decompress-before-decode
+```
+
+**Step 4: Done — open PR if this is the right branch, or note that mcp/ work can be cherry-picked to its own branch.**

--- a/docs/plans/2026-03-02-synapse-mcp.md
+++ b/docs/plans/2026-03-02-synapse-mcp.md
@@ -898,7 +898,7 @@ Expected: response contains all 5 tool names.
 **Step 3: Push branch**
 
 ```bash
-git push origin fix/broker-decompress-before-decode
+git push origin feat/synapse-mcp
 ```
 
-**Step 4: Done — open PR if this is the right branch, or note that mcp/ work can be cherry-picked to its own branch.**
+**Step 4: Open a PR from `feat/synapse-mcp` → `master`.**

--- a/docs/plans/2026-03-02-synapse-mcp.md
+++ b/docs/plans/2026-03-02-synapse-mcp.md
@@ -581,6 +581,7 @@ git commit -m "feat(mcp): add MCP server entry point with all tool registrations
   "mcpServers": {
     "synapse": {
       "command": "node",
+      
       <!-- IDENTITY-EXCEPTION: functional internal reference — not for public exposure -->
       "args": ["${CLAUDE_PLUGIN_ROOT}/dist/index.js"],
       "env": {
@@ -617,6 +618,7 @@ git commit -m "feat(mcp): add plugin manifest"
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
 <!-- IDENTITY-EXCEPTION: functional internal reference — not for public exposure -->
 PLUGIN_DIR="${HOME}/.claude/plugins/synapse"
 
@@ -639,6 +641,7 @@ fi
 ln -s "$SCRIPT_DIR" "$PLUGIN_DIR"
 echo "Done. Plugin installed at ${PLUGIN_DIR} -> ${SCRIPT_DIR}"
 echo ""
+
 <!-- IDENTITY-EXCEPTION: functional internal reference — not for public exposure -->
 echo "Required environment variables (set in your shell or ~/.claude/settings.json):"
 echo "  SYNAPSE_AGENT   — your agent name"
@@ -740,6 +743,7 @@ cd mcp
 ```
 
 The script builds the TypeScript project and symlinks (Unix) or junctions (Windows)
+
 <!-- IDENTITY-EXCEPTION: functional internal reference — not for public exposure -->
 `mcp/` into `~/.claude/plugins/synapse/`.
 
@@ -760,6 +764,7 @@ $env:SYNAPSE_CLI = "C:\path\to\synapse.exe"
 ## Configuration
 
 Set these environment variables before starting a session (or add to
+
 <!-- IDENTITY-EXCEPTION: functional internal reference — not for public exposure -->
 `~/.claude/settings.json` under `env`):
 

--- a/mcp/.gitignore
+++ b/mcp/.gitignore
@@ -1,0 +1,2 @@
+dist/
+node_modules/

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -80,11 +80,8 @@ Expected: JSON response listing all 5 tools.
 ### 2. Send a message
 
 ```bash
-export SYNAPSE_AGENT=my-agent
-export SYNAPSE_SECRET=my-secret
-export SYNAPSE_HOST=synapse.example.com:7777
-export SYNAPSE_CA=/etc/synapse/ca.pem
-synapse send --channel '#general' "test from mcp smoke"
+printf '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"test","version":"0.0.1"}}}\n{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"synapse_send_message","arguments":{"channel":"#general","message":"test from mcp smoke"}}}\n' \
+  | SYNAPSE_AGENT=my-agent SYNAPSE_SECRET=my-secret SYNAPSE_HOST=synapse.example.com:7777 node dist/index.js 2>/dev/null
 ```
 
 ### 3. Poll a channel

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -1,0 +1,98 @@
+# synapse-mcp
+
+TypeScript MCP server for Synapse fleet communications. Wraps the `synapse` CLI
+binary and exposes fleet channels as native MCP tools.
+
+## Requirements
+
+- Node.js 18+
+- The `synapse` CLI binary (from `make cli-linux` in the Synapse repo root, or the pre-built release)
+
+## Installation
+
+### Unix
+
+```bash
+cd mcp
+./install.sh
+```
+
+### Windows
+
+```powershell
+cd mcp
+.\install.ps1
+```
+
+The script builds the TypeScript project and symlinks (Unix) or junctions (Windows)
+<!-- IDENTITY-EXCEPTION: functional internal reference — not for public exposure -->
+`mcp/` into `~/.claude/plugins/synapse/`.
+
+### Manual binary setup
+
+If `synapse` is not in your PATH, set:
+
+```bash
+export SYNAPSE_CLI=/path/to/synapse
+```
+
+Or on Windows:
+
+```powershell
+$env:SYNAPSE_CLI = "C:\path\to\synapse.exe"
+```
+
+## Configuration
+
+Set these environment variables before starting a session (or add to your settings `env` block):
+
+| Variable | Required | Default | Description |
+|----------|----------|---------|-------------|
+| `SYNAPSE_AGENT` | Yes | — | Your agent name |
+| `SYNAPSE_SECRET` | Yes | — | Your agent secret |
+| `SYNAPSE_HOST` | No | `localhost:7777` | Broker address |
+| `SYNAPSE_CA` | No | `/etc/synapse/ca.pem` | CA certificate path |
+| `SYNAPSE_CLI` | No | `synapse` (PATH) | Path to synapse binary |
+
+## Tools
+
+| Tool | Description |
+|------|-------------|
+| `synapse_send_message` | Send a message to a channel |
+| `synapse_listen_poll` | Poll a channel for N seconds, return all messages |
+| `synapse_wait_for_reply` | Wait for a reply with early-exit on first message |
+| `synapse_list_channels` | Stub — creates a task-queue reminder |
+| `synapse_get_channel_history` | Stub — creates a task-queue reminder |
+
+## Smoke Tests
+
+Run these manually after installation to verify the integration.
+
+### 1. Tool discovery
+
+```bash
+printf '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"test","version":"0.0.1"}}}\n{"jsonrpc":"2.0","id":2,"method":"tools/list","params":{}}\n' \
+  | SYNAPSE_AGENT=test SYNAPSE_SECRET=test node dist/index.js 2>/dev/null
+```
+
+Expected: JSON response listing all 5 tools.
+
+### 2. Send a message
+
+```bash
+export SYNAPSE_AGENT=my-agent
+export SYNAPSE_SECRET=my-secret
+export SYNAPSE_HOST=synapse.example.com:7777
+export SYNAPSE_CA=/etc/synapse/ca.pem
+synapse send --channel '#general' "test from mcp smoke"
+```
+
+### 3. Poll a channel
+
+With `SYNAPSE_*` env vars set, call `synapse_listen_poll` with `{"channel":"#general","timeout_seconds":5}`.
+Expected: JSON array of messages received in the window.
+
+### 4. Wait for reply
+
+Call `synapse_wait_for_reply` with `{"channel":"#general","timeout_seconds":10}`, then send a message
+from another agent. Expected: `{ "timedOut": false, "messages": ["..."] }`.

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -92,7 +92,7 @@ synapse send --channel '#general' "test from mcp smoke"
 With `SYNAPSE_*` env vars set, call `synapse_listen_poll` with `{"channel":"#general","timeout_seconds":5}`.
 Expected: JSON array of messages received in the window.
 
-### 4. Wait for reply
+### 4. Wait for a reply
 
 Call `synapse_wait_for_reply` with `{"channel":"#general","timeout_seconds":10}`, then send a message
 from another agent. Expected: `{ "timedOut": false, "messages": ["..."] }`.

--- a/mcp/install.ps1
+++ b/mcp/install.ps1
@@ -1,0 +1,37 @@
+#Requires -Version 5.1
+$ErrorActionPreference = "Stop"
+
+$ScriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+$PluginDir = Join-Path $env:USERPROFILE ".claude\plugins\synapse"
+
+Write-Host "Building synapse-mcp..."
+Set-Location $ScriptDir
+npm install
+npm run build
+
+Write-Host "Installing plugin to $PluginDir ..."
+$PluginsParent = Split-Path -Parent $PluginDir
+if (-not (Test-Path $PluginsParent)) {
+    New-Item -ItemType Directory -Path $PluginsParent | Out-Null
+}
+
+if (Test-Path $PluginDir) {
+    $item = Get-Item $PluginDir
+    if ($item.Attributes -band [System.IO.FileAttributes]::ReparsePoint) {
+        Write-Host "Removing existing junction at $PluginDir"
+        Remove-Item $PluginDir -Force
+    } else {
+        Write-Error "ERROR: $PluginDir exists and is not a junction. Remove it manually before installing."
+        exit 1
+    }
+}
+
+cmd /c "mklink /J `"$PluginDir`" `"$ScriptDir`"" | Out-Null
+Write-Host "Done. Plugin installed at $PluginDir -> $ScriptDir"
+Write-Host ""
+Write-Host "Required environment variables:"
+Write-Host "  SYNAPSE_AGENT   -- your agent name"
+Write-Host "  SYNAPSE_SECRET  -- your agent secret"
+Write-Host "  SYNAPSE_HOST    -- broker address (default: localhost:7777)"
+Write-Host "  SYNAPSE_CA      -- CA cert path (default: /etc/synapse/ca.pem)"
+Write-Host "  SYNAPSE_CLI     -- path to synapse binary (default: synapse in PATH)"

--- a/mcp/install.ps1
+++ b/mcp/install.ps1
@@ -4,12 +4,14 @@ $ErrorActionPreference = "Stop"
 $ScriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
 $PluginDir = Join-Path $env:USERPROFILE ".claude\plugins\synapse"
 
-Write-Host "Building synapse-mcp..."
+Write-Output "Building synapse-mcp..."
 Set-Location $ScriptDir
-npm install
+npm ci
+if ($LASTEXITCODE -ne 0) { throw "npm ci failed with exit code $LASTEXITCODE" }
 npm run build
+if ($LASTEXITCODE -ne 0) { throw "npm run build failed with exit code $LASTEXITCODE" }
 
-Write-Host "Installing plugin to $PluginDir ..."
+Write-Output "Installing plugin to $PluginDir ..."
 $PluginsParent = Split-Path -Parent $PluginDir
 if (-not (Test-Path $PluginsParent)) {
     New-Item -ItemType Directory -Path $PluginsParent | Out-Null
@@ -18,7 +20,7 @@ if (-not (Test-Path $PluginsParent)) {
 if (Test-Path $PluginDir) {
     $item = Get-Item $PluginDir
     if ($item.Attributes -band [System.IO.FileAttributes]::ReparsePoint) {
-        Write-Host "Removing existing junction at $PluginDir"
+        Write-Output "Removing existing junction at $PluginDir"
         Remove-Item $PluginDir -Force
     } else {
         Write-Error "ERROR: $PluginDir exists and is not a junction. Remove it manually before installing."
@@ -28,10 +30,10 @@ if (Test-Path $PluginDir) {
 
 cmd /c "mklink /J `"$PluginDir`" `"$ScriptDir`"" | Out-Null
 Write-Host "Done. Plugin installed at $PluginDir -> $ScriptDir"
-Write-Host ""
-Write-Host "Required environment variables:"
-Write-Host "  SYNAPSE_AGENT   -- your agent name"
-Write-Host "  SYNAPSE_SECRET  -- your agent secret"
-Write-Host "  SYNAPSE_HOST    -- broker address (default: localhost:7777)"
-Write-Host "  SYNAPSE_CA      -- CA cert path (default: /etc/synapse/ca.pem)"
-Write-Host "  SYNAPSE_CLI     -- path to synapse binary (default: synapse in PATH)"
+Write-Output ""
+Write-Output "Required environment variables:"
+Write-Output "  SYNAPSE_AGENT   -- your agent name"
+Write-Output "  SYNAPSE_SECRET  -- your agent secret"
+Write-Output "  SYNAPSE_HOST    -- broker address (default: localhost:7777)"
+Write-Output "  SYNAPSE_CA      -- CA cert path (default: /etc/synapse/ca.pem)"
+Write-Output "  SYNAPSE_CLI     -- path to synapse binary (default: synapse in PATH)"

--- a/mcp/install.ps1
+++ b/mcp/install.ps1
@@ -29,7 +29,8 @@ if (Test-Path $PluginDir) {
 }
 
 cmd /c "mklink /J `"$PluginDir`" `"$ScriptDir`"" | Out-Null
-Write-Host "Done. Plugin installed at $PluginDir -> $ScriptDir"
+if ($LASTEXITCODE -ne 0) { throw "mklink failed with exit code $LASTEXITCODE" }
+Write-Output "Done. Plugin installed at $PluginDir -> $ScriptDir"
 Write-Output ""
 Write-Output "Required environment variables:"
 Write-Output "  SYNAPSE_AGENT   -- your agent name"

--- a/mcp/install.sh
+++ b/mcp/install.sh
@@ -5,6 +5,8 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # IDENTITY-EXCEPTION: functional internal reference — not for public exposure
 PLUGIN_DIR="${HOME}/.claude/plugins/synapse"
 
+command -v npm >/dev/null 2>&1 || { echo "ERROR: npm not found in PATH. Install Node.js first."; exit 1; }
+
 echo "Building synapse-mcp..."
 cd "$SCRIPT_DIR"
 npm ci
@@ -16,6 +18,9 @@ mkdir -p "$(dirname "$PLUGIN_DIR")"
 if [ -L "$PLUGIN_DIR" ]; then
   echo "Removing existing symlink at ${PLUGIN_DIR}"
   rm "$PLUGIN_DIR"
+elif [ -f "$PLUGIN_DIR" ]; then
+  echo "ERROR: ${PLUGIN_DIR} exists and is a regular file. Remove it manually before installing."
+  exit 1
 elif [ -d "$PLUGIN_DIR" ]; then
   echo "ERROR: ${PLUGIN_DIR} exists and is not a symlink. Remove it manually before installing."
   exit 1

--- a/mcp/install.sh
+++ b/mcp/install.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# IDENTITY-EXCEPTION: functional internal reference — not for public exposure
+PLUGIN_DIR="${HOME}/.claude/plugins/synapse"
+
+echo "Building synapse-mcp..."
+cd "$SCRIPT_DIR"
+npm install
+npm run build
+
+echo "Installing plugin to ${PLUGIN_DIR}..."
+mkdir -p "$(dirname "$PLUGIN_DIR")"
+
+if [ -L "$PLUGIN_DIR" ]; then
+  echo "Removing existing symlink at ${PLUGIN_DIR}"
+  rm "$PLUGIN_DIR"
+elif [ -d "$PLUGIN_DIR" ]; then
+  echo "ERROR: ${PLUGIN_DIR} exists and is not a symlink. Remove it manually before installing."
+  exit 1
+fi
+
+ln -s "$SCRIPT_DIR" "$PLUGIN_DIR"
+echo "Done. Plugin installed at ${PLUGIN_DIR} -> ${SCRIPT_DIR}"
+echo ""
+echo "Required environment variables (set in your shell or settings.json env block):"
+echo "  SYNAPSE_AGENT   — your agent name"
+echo "  SYNAPSE_SECRET  — your agent secret"
+echo "  SYNAPSE_HOST    — broker address (default: localhost:7777)"
+echo "  SYNAPSE_CA      — CA cert path (default: /etc/synapse/ca.pem)"
+echo "  SYNAPSE_CLI     — path to synapse binary (default: synapse in PATH)"

--- a/mcp/install.sh
+++ b/mcp/install.sh
@@ -7,7 +7,7 @@ PLUGIN_DIR="${HOME}/.claude/plugins/synapse"
 
 echo "Building synapse-mcp..."
 cd "$SCRIPT_DIR"
-npm install
+npm ci
 npm run build
 
 echo "Installing plugin to ${PLUGIN_DIR}..."

--- a/mcp/package-lock.json
+++ b/mcp/package-lock.json
@@ -1,0 +1,1174 @@
+{
+  "name": "synapse-mcp",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "synapse-mcp",
+      "version": "0.1.0",
+      "dependencies": {
+        "@modelcontextprotocol/sdk": "^1.0.0",
+        "zod": "^3.22.0"
+      },
+      "devDependencies": {
+        "@types/node": "^20.0.0",
+        "typescript": "^5.3.0"
+      }
+    },
+    "node_modules/@hono/node-server": {
+      "version": "1.19.9",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.9.tgz",
+      "integrity": "sha512-vHL6w3ecZsky+8P5MD+eFfaGTyCeOHUIFYMGpQGbrBTSmNNoxv0if69rEZ5giu36weC5saFuznL411gRX7bJDw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.14.1"
+      },
+      "peerDependencies": {
+        "hono": "^4"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk": {
+      "version": "1.27.1",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.27.1.tgz",
+      "integrity": "sha512-sr6GbP+4edBwFndLbM60gf07z0FQ79gaExpnsjMGePXqFcSSb7t6iscpjk9DhFhwd+mTEQrzNafGP8/iGGFYaA==",
+      "license": "MIT",
+      "dependencies": {
+        "@hono/node-server": "^1.19.9",
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
+        "content-type": "^1.0.5",
+        "cors": "^2.8.5",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
+        "express": "^5.2.1",
+        "express-rate-limit": "^8.2.1",
+        "hono": "^4.11.4",
+        "jose": "^6.1.3",
+        "json-schema-typed": "^8.0.2",
+        "pkce-challenge": "^5.0.0",
+        "raw-body": "^3.0.0",
+        "zod": "^3.25 || ^4.0",
+        "zod-to-json-schema": "^3.25.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@cfworker/json-schema": "^4.1.1",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "@cfworker/json-schema": {
+          "optional": true
+        },
+        "zod": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "20.19.35",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.35.tgz",
+      "integrity": "sha512-Uarfe6J91b9HAUXxjvSOdiO2UPOKLm07Q1oh0JHxoZ1y8HoqxDAu3gVrsrOHeiio0kSsoVBt4wFrKOm0dKxVPQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/body-parser": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
+      "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^1.0.5",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.0",
+        "iconv-lite": "^0.7.0",
+        "on-finished": "^2.4.1",
+        "qs": "^6.14.1",
+        "raw-body": "^3.0.1",
+        "type-is": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/content-disposition": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.0.1.tgz",
+      "integrity": "sha512-oIXISMynqSqm241k6kcQ5UwttDILMK4BiurCfGEREw6+X9jkkpEe5T9FZaApyLGGOnFuyMWZpdolTXMtvEJ08Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
+    "node_modules/cors": {
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
+      "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/eventsource": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
+      "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+      "license": "MIT",
+      "dependencies": {
+        "eventsource-parser": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.6.tgz",
+      "integrity": "sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/express": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.1",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "8.2.1",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.2.1.tgz",
+      "integrity": "sha512-PCZEIEIxqwhzw4KF0n7QF4QqruVTcF73O5kFKUnGOyjbCCgizBBiFaYpd/fnBLUMPw/BWw9OsiN7GgrNYr7j6g==",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "10.0.1"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
+      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/finalhandler": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/hono": {
+      "version": "4.12.3",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.3.tgz",
+      "integrity": "sha512-SFsVSjp8sj5UumXOOFlkZOG6XS9SJDKw0TbwFeV+AJ8xlST8kxK5Z/5EYa111UY8732lK2S/xB653ceuaoGwpg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ip-address": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.0.1.tgz",
+      "integrity": "sha512-NWv9YLW4PoW2B7xtzaS3NCot75m6nK7Icdv0o3lfMceJVRfSoQwqD4wEH5rLwoKJwUiZ/rfpiVBhnaF0FK4HoA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "license": "MIT"
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "license": "ISC"
+    },
+    "node_modules/jose": {
+      "version": "6.1.3",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.1.3.tgz",
+      "integrity": "sha512-0TpaTfihd4QMNwrz/ob2Bp7X04yuxJkjRGi4aKmOqwhov54i6u79oCv7T+C7lo70MKH6BesI3vscD1yb/yzKXQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
+    "node_modules/json-schema-typed": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.3.0.tgz",
+      "integrity": "sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/pkce-challenge": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
+      "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.0.tgz",
+      "integrity": "sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
+    "node_modules/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/serve-static": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
+      "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/type-is": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
+      "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^1.0.5",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
+    },
+    "node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.25.1",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.1.tgz",
+      "integrity": "sha512-pM/SU9d3YAggzi6MtR4h7ruuQlqKtad8e9S0fmxcMi+ueAK5Korys/aWcV9LIIHTVbj01NdzxcnXSN+O74ZIVA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.25 || ^4"
+      }
+    }
+  }
+}

--- a/mcp/package.json
+++ b/mcp/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "synapse-mcp",
+  "version": "0.1.0",
+  "description": "Synapse fleet communications MCP server",
+  "type": "module",
+  "main": "dist/index.js",
+  "scripts": {
+    "build": "tsc --noEmit && tsc",
+    "dev": "tsc --watch"
+  },
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.0.0",
+    "zod": "^3.22.0"
+  },
+  "devDependencies": {
+    "typescript": "^5.3.0",
+    "@types/node": "^20.0.0"
+  }
+}

--- a/mcp/plugin.json
+++ b/mcp/plugin.json
@@ -1,0 +1,18 @@
+{
+  "name": "synapse",
+  "version": "0.1.0",
+  "description": "Synapse fleet communications MCP tools — send, listen, poll channels",
+  "mcpServers": {
+    "synapse": {
+      "command": "node",
+      "args": ["${CLAUDE_PLUGIN_ROOT}/dist/index.js"],
+      "env": {
+        "SYNAPSE_HOST":   "${SYNAPSE_HOST}",
+        "SYNAPSE_CA":     "${SYNAPSE_CA}",
+        "SYNAPSE_AGENT":  "${SYNAPSE_AGENT}",
+        "SYNAPSE_SECRET": "${SYNAPSE_SECRET}",
+        "SYNAPSE_CLI":    "${SYNAPSE_CLI}"
+      }
+    }
+  }
+}

--- a/mcp/src/cli.ts
+++ b/mcp/src/cli.ts
@@ -19,7 +19,7 @@ function resolveBin(): string {
   return process.env.SYNAPSE_CLI ?? "synapse";
 }
 
-/** Build child process env — passes all SYNAPSE_* vars through. */
+/** Build child process env — passes through the full process environment. */
 function buildEnv(): NodeJS.ProcessEnv {
   return { ...process.env };
 }

--- a/mcp/src/cli.ts
+++ b/mcp/src/cli.ts
@@ -87,14 +87,17 @@ export async function runWithTimeout(
     const messages: string[] = [];
     let stderr = "";
     let settled = false;
+    let firstLine = true;
 
-    // Declare timer variable before error handler so the error handler can clear it.
+    // Declare timer and rl before error handler so the handler can reference them.
     let timer: ReturnType<typeof setTimeout>;
+    let rl: ReturnType<typeof createInterface>;
 
     child.on("error", (err: NodeJS.ErrnoException) => {
       if (settled) return;
       settled = true;
       clearTimeout(timer);
+      rl?.close();
       if (err.code === "ENOENT") {
         reject(new Error(
           `synapse CLI not found. Set SYNAPSE_CLI or add synapse to PATH. ` +
@@ -107,12 +110,13 @@ export async function runWithTimeout(
 
     child.stderr.on("data", (d: Buffer) => { stderr += d.toString(); });
 
-    const rl = createInterface({ input: child.stdout, crlfDelay: Infinity });
+    rl = createInterface({ input: child.stdout, crlfDelay: Infinity });
 
     rl.on("line", (line: string) => {
       if (settled) return;
-      // Filter the initial status line from `synapse listen`
-      if (line.startsWith("Listening on ")) return;
+      // Filter the initial status line emitted once by `synapse listen` at startup.
+      if (firstLine && line.startsWith("Listening on ")) { firstLine = false; return; }
+      firstLine = false;
       if (line === "") return;
       messages.push(line);
       if (onLine && onLine(line, messages)) {

--- a/mcp/src/cli.ts
+++ b/mcp/src/cli.ts
@@ -1,0 +1,130 @@
+import { spawn } from "child_process";
+import { createInterface } from "readline";
+
+export interface RunResult {
+  stdout: string;
+  stderr: string;
+  code: number;
+}
+
+export interface PollResult {
+  messages: string[];
+  timedOut: boolean;
+}
+
+/** Resolve synapse binary path. SYNAPSE_CLI overrides; falls back to "synapse" in PATH. */
+function resolveBin(): string {
+  return process.env.SYNAPSE_CLI ?? "synapse";
+}
+
+/** Build child process env — passes all SYNAPSE_* vars through. */
+function buildEnv(): NodeJS.ProcessEnv {
+  return { ...process.env };
+}
+
+/** Returns an error string if required SYNAPSE_* vars are missing, else null. */
+export function validateCredentials(): string | null {
+  const required = ["SYNAPSE_AGENT", "SYNAPSE_SECRET"];
+  const missing = required.filter((k) => !process.env[k]);
+  if (missing.length === 0) return null;
+  return `Missing required environment variables: ${missing.join(", ")}. Set them before starting the MCP server.`;
+}
+
+/**
+ * Spawn synapse with the given args, wait for exit.
+ * Used by send_message.
+ */
+export async function runOnce(args: string[]): Promise<RunResult> {
+  const bin = resolveBin();
+  return new Promise((resolve, reject) => {
+    const child = spawn(bin, args, {
+      env: buildEnv(),
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+
+    let stdout = "";
+    let stderr = "";
+
+    child.stdout.on("data", (d: Buffer) => { stdout += d.toString(); });
+    child.stderr.on("data", (d: Buffer) => { stderr += d.toString(); });
+
+    child.on("error", (err: NodeJS.ErrnoException) => {
+      if (err.code === "ENOENT") {
+        reject(new Error(
+          `synapse CLI not found. Set SYNAPSE_CLI or add synapse to PATH. ` +
+          `See mcp/README.md or run mcp/install.sh to set up the Synapse CLI.`
+        ));
+      } else {
+        reject(err);
+      }
+    });
+
+    child.on("close", (code: number | null) => {
+      resolve({ stdout: stdout.trim(), stderr: stderr.trim(), code: code ?? 1 });
+    });
+  });
+}
+
+/**
+ * Spawn synapse with the given args, collect stdout lines for timeoutMs.
+ * onLine is called for each line; return true to exit early (e.g. enough messages received).
+ * Used by listen_poll and wait_for_reply.
+ */
+export async function runWithTimeout(
+  args: string[],
+  timeoutMs: number,
+  onLine?: (line: string, collected: string[]) => boolean
+): Promise<PollResult> {
+  const bin = resolveBin();
+  return new Promise((resolve, reject) => {
+    const child = spawn(bin, args, {
+      env: buildEnv(),
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+
+    const messages: string[] = [];
+    let settled = false;
+
+    child.on("error", (err: NodeJS.ErrnoException) => {
+      if (err.code === "ENOENT") {
+        reject(new Error(
+          `synapse CLI not found. Set SYNAPSE_CLI or add synapse to PATH. ` +
+          `See mcp/README.md or run mcp/install.sh to set up the Synapse CLI.`
+        ));
+      } else {
+        reject(err);
+      }
+    });
+
+    const rl = createInterface({ input: child.stdout, crlfDelay: Infinity });
+
+    rl.on("line", (line: string) => {
+      // Filter the initial status line from `synapse listen`
+      if (line.startsWith("Listening on ")) return;
+      if (line === "") return;
+      messages.push(line);
+      if (!settled && onLine && onLine(line, messages)) {
+        settled = true;
+        clearTimeout(timer);
+        child.kill("SIGTERM");
+        resolve({ messages, timedOut: false });
+      }
+    });
+
+    const timer = setTimeout(() => {
+      if (!settled) {
+        settled = true;
+        child.kill("SIGTERM");
+        resolve({ messages, timedOut: true });
+      }
+    }, timeoutMs);
+
+    child.on("close", () => {
+      if (!settled) {
+        settled = true;
+        clearTimeout(timer);
+        resolve({ messages, timedOut: false });
+      }
+    });
+  });
+}

--- a/mcp/src/cli.ts
+++ b/mcp/src/cli.ts
@@ -85,7 +85,13 @@ export async function runWithTimeout(
     const messages: string[] = [];
     let settled = false;
 
+    // Declare timer variable before error handler so the error handler can clear it.
+    let timer: ReturnType<typeof setTimeout>;
+
     child.on("error", (err: NodeJS.ErrnoException) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
       if (err.code === "ENOENT") {
         reject(new Error(
           `synapse CLI not found. Set SYNAPSE_CLI or add synapse to PATH. ` +
@@ -99,21 +105,24 @@ export async function runWithTimeout(
     const rl = createInterface({ input: child.stdout, crlfDelay: Infinity });
 
     rl.on("line", (line: string) => {
+      if (settled) return;
       // Filter the initial status line from `synapse listen`
       if (line.startsWith("Listening on ")) return;
       if (line === "") return;
       messages.push(line);
-      if (!settled && onLine && onLine(line, messages)) {
+      if (onLine && onLine(line, messages)) {
         settled = true;
         clearTimeout(timer);
+        rl.close();
         child.kill("SIGTERM");
         resolve({ messages, timedOut: false });
       }
     });
 
-    const timer = setTimeout(() => {
+    timer = setTimeout(() => {
       if (!settled) {
         settled = true;
+        rl.close();
         child.kill("SIGTERM");
         resolve({ messages, timedOut: true });
       }

--- a/mcp/src/cli.ts
+++ b/mcp/src/cli.ts
@@ -10,6 +10,8 @@ export interface RunResult {
 export interface PollResult {
   messages: string[];
   timedOut: boolean;
+  exitCode: number | null;
+  stderr: string;
 }
 
 /** Resolve synapse binary path. SYNAPSE_CLI overrides; falls back to "synapse" in PATH. */
@@ -52,7 +54,7 @@ export async function runOnce(args: string[]): Promise<RunResult> {
       if (err.code === "ENOENT") {
         reject(new Error(
           `synapse CLI not found. Set SYNAPSE_CLI or add synapse to PATH. ` +
-          `See mcp/README.md or run mcp/install.sh to set up the Synapse CLI.`
+          `See mcp/README.md or run mcp/install.sh (Unix) / mcp/install.ps1 (Windows).`
         ));
       } else {
         reject(err);
@@ -83,6 +85,7 @@ export async function runWithTimeout(
     });
 
     const messages: string[] = [];
+    let stderr = "";
     let settled = false;
 
     // Declare timer variable before error handler so the error handler can clear it.
@@ -95,12 +98,14 @@ export async function runWithTimeout(
       if (err.code === "ENOENT") {
         reject(new Error(
           `synapse CLI not found. Set SYNAPSE_CLI or add synapse to PATH. ` +
-          `See mcp/README.md or run mcp/install.sh to set up the Synapse CLI.`
+          `See mcp/README.md or run mcp/install.sh (Unix) / mcp/install.ps1 (Windows).`
         ));
       } else {
         reject(err);
       }
     });
+
+    child.stderr.on("data", (d: Buffer) => { stderr += d.toString(); });
 
     const rl = createInterface({ input: child.stdout, crlfDelay: Infinity });
 
@@ -115,7 +120,7 @@ export async function runWithTimeout(
         clearTimeout(timer);
         rl.close();
         child.kill("SIGTERM");
-        resolve({ messages, timedOut: false });
+        resolve({ messages, timedOut: false, exitCode: null, stderr: stderr.trim() });
       }
     });
 
@@ -124,15 +129,15 @@ export async function runWithTimeout(
         settled = true;
         rl.close();
         child.kill("SIGTERM");
-        resolve({ messages, timedOut: true });
+        resolve({ messages, timedOut: true, exitCode: null, stderr: stderr.trim() });
       }
     }, timeoutMs);
 
-    child.on("close", () => {
+    child.on("close", (code: number | null) => {
       if (!settled) {
         settled = true;
         clearTimeout(timer);
-        resolve({ messages, timedOut: false });
+        resolve({ messages, timedOut: false, exitCode: code, stderr: stderr.trim() });
       }
     });
   });

--- a/mcp/src/index.ts
+++ b/mcp/src/index.ts
@@ -27,9 +27,8 @@ server.setRequestHandler(ListToolsRequestSchema, async () => ({ tools }));
 server.setRequestHandler(CallToolRequestSchema, async (request) => {
   const { name, arguments: args } = request.params;
 
-  let text: string;
-  let isError = false;
   try {
+    let text: string;
     switch (name) {
       case "synapse_send_message":        text = await handleSendMessage(args); break;
       case "synapse_listen_poll":         text = await handleListenPoll(args); break;
@@ -42,14 +41,9 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
           isError: true,
         };
     }
-    // Detect known error response patterns from handlers
-    if (
-      text.startsWith("Missing required") ||
-      text.startsWith("Send failed") ||
-      text.startsWith("synapse CLI not found")
-    ) {
-      isError = true;
-    }
+    // Detect send failure reported as a string (non-zero CLI exit code).
+    const isError = text.startsWith("Send failed");
+    return { content: [{ type: "text" as const, text }], isError };
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
     return {
@@ -57,8 +51,6 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
       isError: true,
     };
   }
-
-  return { content: [{ type: "text" as const, text }], isError };
 });
 
 const transport = new StdioServerTransport();

--- a/mcp/src/index.ts
+++ b/mcp/src/index.ts
@@ -41,9 +41,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
           isError: true,
         };
     }
-    // Detect send failure reported as a string (non-zero CLI exit code).
-    const isError = text.startsWith("Send failed");
-    return { content: [{ type: "text" as const, text }], isError };
+    return { content: [{ type: "text" as const, text }] };
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
     return {

--- a/mcp/src/index.ts
+++ b/mcp/src/index.ts
@@ -1,0 +1,56 @@
+import { Server } from "@modelcontextprotocol/sdk/server/index.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import {
+  CallToolRequestSchema,
+  ListToolsRequestSchema,
+} from "@modelcontextprotocol/sdk/types.js";
+
+import { sendMessageTool, handleSendMessage } from "./tools/send.js";
+import { listenPollTool, waitForReplyTool, handleListenPoll, handleWaitForReply } from "./tools/listen.js";
+import { listChannelsTool, getChannelHistoryTool, handleListChannels, handleGetChannelHistory } from "./tools/stubs.js";
+
+const server = new Server(
+  { name: "synapse", version: "0.1.0" },
+  { capabilities: { tools: {} } }
+);
+
+const tools = [
+  sendMessageTool,
+  listenPollTool,
+  waitForReplyTool,
+  listChannelsTool,
+  getChannelHistoryTool,
+];
+
+server.setRequestHandler(ListToolsRequestSchema, async () => ({ tools }));
+
+server.setRequestHandler(CallToolRequestSchema, async (request) => {
+  const { name, arguments: args } = request.params;
+
+  let text: string;
+  try {
+    switch (name) {
+      case "synapse_send_message":       text = await handleSendMessage(args); break;
+      case "synapse_listen_poll":        text = await handleListenPoll(args); break;
+      case "synapse_wait_for_reply":     text = await handleWaitForReply(args); break;
+      case "synapse_list_channels":      text = await handleListChannels(args); break;
+      case "synapse_get_channel_history": text = await handleGetChannelHistory(args); break;
+      default:
+        return {
+          content: [{ type: "text" as const, text: `Unknown tool: ${name}` }],
+          isError: true,
+        };
+    }
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return {
+      content: [{ type: "text" as const, text: `Tool error: ${message}` }],
+      isError: true,
+    };
+  }
+
+  return { content: [{ type: "text" as const, text }] };
+});
+
+const transport = new StdioServerTransport();
+await server.connect(transport);

--- a/mcp/src/index.ts
+++ b/mcp/src/index.ts
@@ -28,18 +28,27 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
   const { name, arguments: args } = request.params;
 
   let text: string;
+  let isError = false;
   try {
     switch (name) {
-      case "synapse_send_message":       text = await handleSendMessage(args); break;
-      case "synapse_listen_poll":        text = await handleListenPoll(args); break;
-      case "synapse_wait_for_reply":     text = await handleWaitForReply(args); break;
-      case "synapse_list_channels":      text = await handleListChannels(args); break;
+      case "synapse_send_message":        text = await handleSendMessage(args); break;
+      case "synapse_listen_poll":         text = await handleListenPoll(args); break;
+      case "synapse_wait_for_reply":      text = await handleWaitForReply(args); break;
+      case "synapse_list_channels":       text = await handleListChannels(args); break;
       case "synapse_get_channel_history": text = await handleGetChannelHistory(args); break;
       default:
         return {
           content: [{ type: "text" as const, text: `Unknown tool: ${name}` }],
           isError: true,
         };
+    }
+    // Detect known error response patterns from handlers
+    if (
+      text.startsWith("Missing required") ||
+      text.startsWith("Send failed") ||
+      text.startsWith("synapse CLI not found")
+    ) {
+      isError = true;
     }
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
@@ -49,7 +58,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
     };
   }
 
-  return { content: [{ type: "text" as const, text }] };
+  return { content: [{ type: "text" as const, text }], isError };
 });
 
 const transport = new StdioServerTransport();

--- a/mcp/src/tools/listen.ts
+++ b/mcp/src/tools/listen.ts
@@ -1,0 +1,87 @@
+import { z } from "zod";
+import { runWithTimeout, validateCredentials } from "../cli.js";
+
+export const ListenPollSchema = z.object({
+  channel: z.string().describe("Channel name, e.g. #general"),
+  timeout_seconds: z.number().int().min(1).max(120).default(5)
+    .describe("How long to collect messages before returning (default 5s)"),
+});
+
+export const WaitForReplySchema = z.object({
+  channel: z.string().describe("Channel name, e.g. #general"),
+  timeout_seconds: z.number().int().min(1).max(300).default(30)
+    .describe("Maximum time to wait for replies (default 30s)"),
+  min_messages: z.number().int().min(1).default(1)
+    .describe("Exit early once this many messages are received (default 1)"),
+});
+
+export const listenPollTool = {
+  name: "synapse_listen_poll",
+  description:
+    "Poll a Synapse channel for messages. Listens for timeout_seconds and returns all messages received. " +
+    "Empty array means the channel was quiet — not an error.",
+  inputSchema: {
+    type: "object" as const,
+    properties: {
+      channel: { type: "string", description: "Channel name, e.g. #general" },
+      timeout_seconds: {
+        type: "number",
+        description: "How long to collect messages (default 5s, max 120s)",
+        default: 5,
+      },
+    },
+    required: ["channel"],
+  },
+};
+
+export const waitForReplyTool = {
+  name: "synapse_wait_for_reply",
+  description:
+    "Wait for a reply on a Synapse channel. Exits as soon as min_messages arrive or timeout_seconds elapses. " +
+    "Use after synapse_send_message to receive the response in a conversation loop. " +
+    "Returns { timedOut, messages }.",
+  inputSchema: {
+    type: "object" as const,
+    properties: {
+      channel: { type: "string", description: "Channel name, e.g. #general" },
+      timeout_seconds: {
+        type: "number",
+        description: "Maximum wait time in seconds (default 30s, max 300s)",
+        default: 30,
+      },
+      min_messages: {
+        type: "number",
+        description: "Exit early once this many messages are received (default 1)",
+        default: 1,
+      },
+    },
+    required: ["channel"],
+  },
+};
+
+export async function handleListenPoll(args: unknown): Promise<string> {
+  const credErr = validateCredentials();
+  if (credErr) return credErr;
+
+  const { channel, timeout_seconds } = ListenPollSchema.parse(args);
+  const result = await runWithTimeout(
+    ["listen", "--channel", channel],
+    timeout_seconds * 1000
+  );
+
+  return JSON.stringify(result.messages);
+}
+
+export async function handleWaitForReply(args: unknown): Promise<string> {
+  const credErr = validateCredentials();
+  if (credErr) return credErr;
+
+  const { channel, timeout_seconds, min_messages } = WaitForReplySchema.parse(args);
+  const result = await runWithTimeout(
+    ["listen", "--channel", channel],
+    timeout_seconds * 1000,
+    (_line, collected) => collected.length >= min_messages
+  );
+
+  return JSON.stringify({ timedOut: result.timedOut, messages: result.messages });
+}

--- a/mcp/src/tools/listen.ts
+++ b/mcp/src/tools/listen.ts
@@ -11,8 +11,8 @@ export const WaitForReplySchema = z.object({
   channel: z.string().describe("Channel name, e.g. #general"),
   timeout_seconds: z.number().int().min(1).max(300).default(30)
     .describe("Maximum time to wait for replies (default 30s)"),
-  min_messages: z.number().int().min(1).default(1)
-    .describe("Exit early once this many messages are received (default 1)"),
+  min_messages: z.number().int().min(1).max(1000).default(1)
+    .describe("Exit early once this many messages are received (default 1, max 1000)"),
 });
 
 export const listenPollTool = {
@@ -61,7 +61,7 @@ export const waitForReplyTool = {
 
 export async function handleListenPoll(args: unknown): Promise<string> {
   const credErr = validateCredentials();
-  if (credErr) return credErr;
+  if (credErr) return JSON.stringify({ error: credErr });
 
   const { channel, timeout_seconds } = ListenPollSchema.parse(args);
   const result = await runWithTimeout(
@@ -74,7 +74,7 @@ export async function handleListenPoll(args: unknown): Promise<string> {
 
 export async function handleWaitForReply(args: unknown): Promise<string> {
   const credErr = validateCredentials();
-  if (credErr) return credErr;
+  if (credErr) return JSON.stringify({ error: credErr });
 
   const { channel, timeout_seconds, min_messages } = WaitForReplySchema.parse(args);
   const result = await runWithTimeout(

--- a/mcp/src/tools/listen.ts
+++ b/mcp/src/tools/listen.ts
@@ -69,6 +69,10 @@ export async function handleListenPoll(args: unknown): Promise<string> {
     timeout_seconds * 1000
   );
 
+  if (result.exitCode !== null && result.exitCode !== 0) {
+    throw new Error(`synapse listen failed (exit ${result.exitCode}): ${result.stderr.trim()}`);
+  }
+
   return JSON.stringify(result.messages);
 }
 
@@ -82,6 +86,10 @@ export async function handleWaitForReply(args: unknown): Promise<string> {
     timeout_seconds * 1000,
     (_line, collected) => collected.length >= min_messages
   );
+
+  if (result.exitCode !== null && result.exitCode !== 0) {
+    throw new Error(`synapse listen failed (exit ${result.exitCode}): ${result.stderr.trim()}`);
+  }
 
   return JSON.stringify({ timedOut: result.timedOut, messages: result.messages });
 }

--- a/mcp/src/tools/listen.ts
+++ b/mcp/src/tools/listen.ts
@@ -61,7 +61,7 @@ export const waitForReplyTool = {
 
 export async function handleListenPoll(args: unknown): Promise<string> {
   const credErr = validateCredentials();
-  if (credErr) return JSON.stringify({ error: credErr });
+  if (credErr) throw new Error(credErr);
 
   const { channel, timeout_seconds } = ListenPollSchema.parse(args);
   const result = await runWithTimeout(
@@ -74,7 +74,7 @@ export async function handleListenPoll(args: unknown): Promise<string> {
 
 export async function handleWaitForReply(args: unknown): Promise<string> {
   const credErr = validateCredentials();
-  if (credErr) return JSON.stringify({ error: credErr });
+  if (credErr) throw new Error(credErr);
 
   const { channel, timeout_seconds, min_messages } = WaitForReplySchema.parse(args);
   const result = await runWithTimeout(

--- a/mcp/src/tools/send.ts
+++ b/mcp/src/tools/send.ts
@@ -2,8 +2,8 @@ import { z } from "zod";
 import { runOnce, validateCredentials } from "../cli.js";
 
 export const SendMessageSchema = z.object({
-  channel: z.string().describe("Channel name, e.g. #general"),
-  message: z.string().describe("Message body to send"),
+  channel: z.string().trim().min(1, "channel must not be empty").describe("Channel name, e.g. #general"),
+  message: z.string().trim().min(1, "message must not be empty").describe("Message body to send"),
 });
 
 export const sendMessageTool = {

--- a/mcp/src/tools/send.ts
+++ b/mcp/src/tools/send.ts
@@ -27,7 +27,7 @@ export async function handleSendMessage(args: unknown): Promise<string> {
   const result = await runOnce(["send", "--channel", channel, message]);
 
   if (result.code !== 0) {
-    return `Send failed (exit ${result.code}): ${result.stderr || result.stdout || "unknown error"}`;
+    throw new Error(`Send failed (exit ${result.code}): ${result.stderr || result.stdout || "unknown error"}`);
   }
 
   return result.stdout || "Delivered.";

--- a/mcp/src/tools/send.ts
+++ b/mcp/src/tools/send.ts
@@ -12,8 +12,8 @@ export const sendMessageTool = {
   inputSchema: {
     type: "object" as const,
     properties: {
-      channel: { type: "string", description: "Channel name, e.g. #general" },
-      message: { type: "string", description: "Message body to send" },
+      channel: { type: "string", description: "Channel name, e.g. #general", minLength: 1 },
+      message: { type: "string", description: "Message body to send", minLength: 1 },
     },
     required: ["channel", "message"],
   },

--- a/mcp/src/tools/send.ts
+++ b/mcp/src/tools/send.ts
@@ -21,7 +21,7 @@ export const sendMessageTool = {
 
 export async function handleSendMessage(args: unknown): Promise<string> {
   const credErr = validateCredentials();
-  if (credErr) return JSON.stringify({ error: credErr });
+  if (credErr) throw new Error(credErr);
 
   const { channel, message } = SendMessageSchema.parse(args);
   const result = await runOnce(["send", "--channel", channel, message]);

--- a/mcp/src/tools/send.ts
+++ b/mcp/src/tools/send.ts
@@ -21,7 +21,7 @@ export const sendMessageTool = {
 
 export async function handleSendMessage(args: unknown): Promise<string> {
   const credErr = validateCredentials();
-  if (credErr) return credErr;
+  if (credErr) return JSON.stringify({ error: credErr });
 
   const { channel, message } = SendMessageSchema.parse(args);
   const result = await runOnce(["send", "--channel", channel, message]);

--- a/mcp/src/tools/send.ts
+++ b/mcp/src/tools/send.ts
@@ -1,0 +1,34 @@
+import { z } from "zod";
+import { runOnce, validateCredentials } from "../cli.js";
+
+export const SendMessageSchema = z.object({
+  channel: z.string().describe("Channel name, e.g. #general"),
+  message: z.string().describe("Message body to send"),
+});
+
+export const sendMessageTool = {
+  name: "synapse_send_message",
+  description: "Send a message to a Synapse fleet channel.",
+  inputSchema: {
+    type: "object" as const,
+    properties: {
+      channel: { type: "string", description: "Channel name, e.g. #general" },
+      message: { type: "string", description: "Message body to send" },
+    },
+    required: ["channel", "message"],
+  },
+};
+
+export async function handleSendMessage(args: unknown): Promise<string> {
+  const credErr = validateCredentials();
+  if (credErr) return credErr;
+
+  const { channel, message } = SendMessageSchema.parse(args);
+  const result = await runOnce(["send", "--channel", channel, message]);
+
+  if (result.code !== 0) {
+    return `Send failed (exit ${result.code}): ${result.stderr || result.stdout || "unknown error"}`;
+  }
+
+  return result.stdout || "Delivered.";
+}

--- a/mcp/src/tools/stubs.ts
+++ b/mcp/src/tools/stubs.ts
@@ -1,0 +1,46 @@
+const STUB_ACTION =
+  "Check TASK-QUEUE.md for a task covering this capability. " +
+  "If none exists, create one. If capacity is free, resolve it now.";
+
+function stubResponse(capability: string): string {
+  return JSON.stringify({
+    status: "not_implemented",
+    capability,
+    action_required: STUB_ACTION,
+  });
+}
+
+export const listChannelsTool = {
+  name: "synapse_list_channels",
+  description:
+    "List available Synapse channels. NOT YET IMPLEMENTED — returns a task-queue reminder.",
+  inputSchema: {
+    type: "object" as const,
+    properties: {},
+    required: [],
+  },
+};
+
+export const getChannelHistoryTool = {
+  name: "synapse_get_channel_history",
+  description:
+    "Fetch message history from a Synapse channel. NOT YET IMPLEMENTED — returns a task-queue reminder.",
+  inputSchema: {
+    type: "object" as const,
+    properties: {
+      channel: { type: "string", description: "Channel name, e.g. #general" },
+      limit: { type: "number", description: "Max messages to return (default 50)", default: 50 },
+    },
+    required: ["channel"],
+  },
+};
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+export async function handleListChannels(_args: unknown): Promise<string> {
+  return stubResponse("synapse_list_channels");
+}
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+export async function handleGetChannelHistory(_args: unknown): Promise<string> {
+  return stubResponse("synapse_get_channel_history");
+}

--- a/mcp/tsconfig.json
+++ b/mcp/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "Node16",
+    "moduleResolution": "Node16",
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "declaration": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["dist", "node_modules"]
+}


### PR DESCRIPTION
## Summary

- Adds `mcp/` TypeScript MCP server co-located in the Synapse monorepo
- Wraps the `synapse` CLI binary and exposes 5 MCP tools: `synapse_send_message`, `synapse_listen_poll`, `synapse_wait_for_reply`, `synapse_list_channels` (stub), `synapse_get_channel_history` (stub)
- `synapse_wait_for_reply` supports conversation loops with configurable timeout and early-exit on first reply
- Stub tools return structured task-queue reminders until CLI is extended
- `install.sh` / `install.ps1` build and symlink/junction the plugin into the local plugin directory
- `make mcp-build` target added to Makefile

## Architecture

- `@modelcontextprotocol/sdk` stdio transport
- Shared `cli.ts` spawner with `runOnce` and `runWithTimeout` primitives
- Credentials via `SYNAPSE_*` environment variables (AGENT, SECRET, HOST, CA, CLI)
- Binary-not-found error references `mcp/README.md` and `mcp/install.sh`

## Test plan

- [ ] `npm run build` succeeds with zero TypeScript errors
- [ ] Tool discovery smoke test: 5 tools listed via stdio JSON-RPC
- [ ] `synapse_send_message` delivers message to live broker
- [ ] `synapse_listen_poll` returns messages from active channel
- [ ] `synapse_wait_for_reply` exits early on receipt
- [ ] Install script creates symlink at expected path
- [ ] `make mcp-build` builds from repo root

## Summary by Sourcery

Add a TypeScript-based MCP server for Synapse that wraps the synapse CLI and integrate its build into the main monorepo.

New Features:
- Introduce a new synapse-mcp TypeScript project exposing Synapse fleet communication as MCP tools over stdio, including send, listen/poll, wait-for-reply, and two stubbed channel tools.
- Provide Unix and Windows installation scripts and a plugin manifest to install and run the MCP server as a Meridian Lex plugin.

Enhancements:
- Add a shared CLI spawner utility to standardize environment handling, credential validation, and process management for synapse CLI calls from MCP tools.
- Integrate an mcp-build target into the root Makefile and include it in the default all build to compile the MCP server from the repo root.

Documentation:
- Add detailed MCP implementation plan and design documents outlining architecture, tools, and integration details for the Synapse MCP server.
- Document MCP server setup, configuration, and smoke-test workflows in a new mcp/README.md.