### PR TITLE
feat(relay): add Dockerfile.relay for synapse-relay sidecar image

### DIFF
--- a/Dockerfile.relay
+++ b/Dockerfile.relay
@@ -1,0 +1,36 @@
+# Stage 1: build
+FROM rust:1.88-slim AS builder
+RUN apt-get update && apt-get install -y --no-install-recommends pkg-config libssl-dev && rm -rf /var/lib/apt/lists/*
+WORKDIR /build
+
+# Copy workspace manifests and fetch dependencies early for better caching
+COPY Cargo.toml Cargo.lock ./
+COPY crates/synapse-proto/Cargo.toml crates/synapse-proto/
+COPY crates/synapse-relay/Cargo.toml crates/synapse-relay/
+RUN mkdir -p crates/synapse-proto/src && echo "" > crates/synapse-proto/src/lib.rs \
+ && mkdir -p crates/synapse-relay/src && echo "fn main(){}" > crates/synapse-relay/src/main.rs \
+ && echo "" >> crates/synapse-relay/src/main.rs
+RUN cargo fetch
+
+# Copy full source and build
+COPY . .
+RUN cargo build --release -p synapse-relay
+
+# Stage 2: runtime
+FROM debian:bookworm-slim
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends ca-certificates libssl3 \
+ && rm -rf /var/lib/apt/lists/*
+
+RUN addgroup --system appuser && adduser --system --ingroup appuser appuser
+
+WORKDIR /app
+COPY --from=builder /build/target/release/synapse-relay /usr/local/bin/synapse-relay
+
+EXPOSE 7779
+HEALTHCHECK --interval=30s --timeout=10s --retries=3 --start-period=10s \
+    CMD ["/usr/local/bin/synapse-relay", "status"]
+
+USER appuser
+ENTRYPOINT ["/usr/local/bin/synapse-relay"]
+CMD ["serve", "--bind", "0.0.0.0", "--port", "7779"]


### PR DESCRIPTION
## Summary

- Adds `Dockerfile.relay` — a dedicated multi-stage build for the `synapse-relay` binary
- Mirrors the existing `Dockerfile` pattern (rust:1.88-slim builder, debian:bookworm-slim runtime, non-root `appuser`)
- Exposes port 7779; healthcheck runs `synapse-relay status` against itself
- Required by the Gantry relay compose (Meridian-Lex/Gantry) which builds this image and runs one container per agent

## Test plan

- [ ] `docker build -f Dockerfile.relay -t synapse-relay:test .` builds successfully
- [ ] Container starts and `synapse-relay status` returns without error (relay listening)
- [ ] Relay connects to broker with valid `SYNAPSE_AGENT`/`SYNAPSE_SECRET` credentials

## Summary by Sourcery

Build:
- Introduce Dockerfile.relay to build a synapse-relay binary via a multi-stage Rust build and package it into a minimal Debian runtime image exposing port 7779.