### PR TITLE
feat(ci): add release workflows for GitHub Actions and Gitea Actions

### DIFF
--- a/.gitea/workflows/release.yml
+++ b/.gitea/workflows/release.yml
@@ -38,12 +38,16 @@ jobs:
           GITEA_TOKEN: ${{ secrets.FLEET_TOKEN }}
           TAG: ${{ gitea.ref_name }}
         run: |
+          set -euo pipefail
+
           VERSION="${TAG#v}"
           REGISTRY="${GITEA_URL}/api/packages/StellarFleetOps/generic"
 
           for BINARY in synapse-broker synapse; do
             echo "Publishing ${BINARY} ${VERSION}..."
-            curl -sf \
+            curl \
+              --fail-with-body \
+              --show-error \
               --retry 5 \
               --retry-delay 5 \
               --retry-max-time 60 \

--- a/.gitea/workflows/release.yml
+++ b/.gitea/workflows/release.yml
@@ -1,0 +1,55 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*.*.*"
+
+jobs:
+  build-publish:
+    name: Build & publish to Gitea registry
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust
+        run: |
+          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain stable
+          echo "$HOME/.cargo/bin" >> $GITHUB_PATH
+
+      - name: Cache cargo registry
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-release-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-release-
+            ${{ runner.os }}-cargo-
+
+      - name: Build release binaries
+        run: cargo build --release --bin synapse-broker --bin synapse
+
+      - name: Publish binaries to Gitea generic registry
+        env:
+          GITEA_URL: http://192.168.0.12:30008
+          GITEA_TOKEN: ${{ secrets.FLEET_TOKEN }}
+          TAG: ${{ gitea.ref_name }}
+        run: |
+          VERSION="${TAG#v}"
+          REGISTRY="${GITEA_URL}/api/packages/StellarFleetOps/generic"
+
+          for BINARY in synapse-broker synapse; do
+            echo "Publishing ${BINARY} ${VERSION}..."
+            curl -sf -X PUT \
+              -H "Authorization: token ${GITEA_TOKEN}" \
+              -H "Content-Type: application/octet-stream" \
+              --data-binary "@target/release/${BINARY}" \
+              "${REGISTRY}/${BINARY}/${VERSION}/${BINARY}-linux-amd64"
+          done
+
+          echo "Published synapse-broker and synapse at ${VERSION}"

--- a/.gitea/workflows/release.yml
+++ b/.gitea/workflows/release.yml
@@ -14,10 +14,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Install Rust
-        run: |
-          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain stable
-          echo "$HOME/.cargo/bin" >> $GITHUB_PATH
+      - name: Set up Rust
+        uses: dtolnay/rust-toolchain@stable
 
       - name: Cache cargo registry
         uses: actions/cache@v4
@@ -36,7 +34,7 @@ jobs:
 
       - name: Publish binaries to Gitea generic registry
         env:
-          GITEA_URL: http://192.168.0.12:30008
+          GITEA_URL: ${{ secrets.GITEA_BASE_URL }}
           GITEA_TOKEN: ${{ secrets.FLEET_TOKEN }}
           TAG: ${{ gitea.ref_name }}
         run: |
@@ -45,7 +43,11 @@ jobs:
 
           for BINARY in synapse-broker synapse; do
             echo "Publishing ${BINARY} ${VERSION}..."
-            curl -sf -X PUT \
+            curl -sf \
+              --retry 5 \
+              --retry-delay 5 \
+              --retry-max-time 60 \
+              -X PUT \
               -H "Authorization: token ${GITEA_TOKEN}" \
               -H "Content-Type: application/octet-stream" \
               --data-binary "@target/release/${BINARY}" \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,10 +6,12 @@ on:
       - "v*.*.*"
 
 jobs:
-  build-publish:
-    name: Build & publish to Gitea registry
+  build-release:
+    name: Build & publish GitHub release
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    permissions:
+      contents: write
 
     steps:
       - uses: actions/checkout@v4
@@ -32,22 +34,13 @@ jobs:
       - name: Build release binaries
         run: cargo build --release --bin synapse-broker --bin synapse
 
-      - name: Publish binaries to Gitea generic registry
+      - name: Create GitHub release and upload binaries
         env:
-          GITEA_URL: http://192.168.0.12:30008
-          GITEA_TOKEN: ${{ secrets.LEXCODE_TOKEN }}
+          GH_TOKEN: ${{ github.token }}
           TAG: ${{ github.ref_name }}
         run: |
-          VERSION="${TAG#v}"
-          REGISTRY="${GITEA_URL}/api/packages/StellarFleetOps/generic"
-
-          for BINARY in synapse-broker synapse; do
-            echo "Publishing ${BINARY} ${VERSION}..."
-            curl -sf -X PUT \
-              -H "Authorization: token ${GITEA_TOKEN}" \
-              -H "Content-Type: application/octet-stream" \
-              --data-binary "@target/release/${BINARY}" \
-              "${REGISTRY}/${BINARY}/${VERSION}/${BINARY}-linux-amd64"
-          done
-
-          echo "Published synapse-broker and synapse at ${VERSION}"
+          gh release create "${TAG}" \
+            --title "${TAG}" \
+            --generate-notes \
+            target/release/synapse-broker \
+            target/release/synapse

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,7 +48,7 @@ jobs:
       - name: Publish binaries to Gitea generic registry
         env:
           GITEA_URL: ${{ secrets.GITEA_BASE_URL }}
-          GITEA_TOKEN: ${{ secrets.FLEET_TOKEN }}
+          GITEA_TOKEN: ${{ secrets.LEXCODE_TOKEN }}
           TAG: ${{ github.ref_name }}
         run: |
           set -euo pipefail

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,12 +51,16 @@ jobs:
           GITEA_TOKEN: ${{ secrets.FLEET_TOKEN }}
           TAG: ${{ github.ref_name }}
         run: |
+          set -euo pipefail
+
           VERSION="${TAG#v}"
           REGISTRY="${GITEA_URL}/api/packages/StellarFleetOps/generic"
 
           for BINARY in synapse-broker synapse; do
             echo "Publishing ${BINARY} ${VERSION}..."
-            curl -sf \
+            curl \
+              --fail-with-body \
+              --show-error \
               --retry 5 \
               --retry-delay 5 \
               --retry-max-time 60 \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,30 +45,3 @@ jobs:
             target/release/synapse-broker \
             target/release/synapse
 
-      - name: Publish binaries to Gitea generic registry
-        env:
-          GITEA_URL: ${{ secrets.GITEA_BASE_URL }}
-          GITEA_TOKEN: ${{ secrets.LEXCODE_TOKEN }}
-          TAG: ${{ github.ref_name }}
-        run: |
-          set -euo pipefail
-
-          VERSION="${TAG#v}"
-          REGISTRY="${GITEA_URL}/api/packages/StellarFleetOps/generic"
-
-          for BINARY in synapse-broker synapse; do
-            echo "Publishing ${BINARY} ${VERSION}..."
-            curl \
-              --fail-with-body \
-              --show-error \
-              --retry 5 \
-              --retry-delay 5 \
-              --retry-max-time 60 \
-              -X PUT \
-              -H "Authorization: token ${GITEA_TOKEN}" \
-              -H "Content-Type: application/octet-stream" \
-              --data-binary "@target/release/${BINARY}" \
-              "${REGISTRY}/${BINARY}/${VERSION}/${BINARY}-linux-amd64"
-          done
-
-          echo "Published synapse-broker and synapse at ${VERSION}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,3 +44,27 @@ jobs:
             --generate-notes \
             target/release/synapse-broker \
             target/release/synapse
+
+      - name: Publish binaries to Gitea generic registry
+        env:
+          GITEA_URL: ${{ secrets.GITEA_BASE_URL }}
+          GITEA_TOKEN: ${{ secrets.FLEET_TOKEN }}
+          TAG: ${{ github.ref_name }}
+        run: |
+          VERSION="${TAG#v}"
+          REGISTRY="${GITEA_URL}/api/packages/StellarFleetOps/generic"
+
+          for BINARY in synapse-broker synapse; do
+            echo "Publishing ${BINARY} ${VERSION}..."
+            curl -sf \
+              --retry 5 \
+              --retry-delay 5 \
+              --retry-max-time 60 \
+              -X PUT \
+              -H "Authorization: token ${GITEA_TOKEN}" \
+              -H "Content-Type: application/octet-stream" \
+              --data-binary "@target/release/${BINARY}" \
+              "${REGISTRY}/${BINARY}/${VERSION}/${BINARY}-linux-amd64"
+          done
+
+          echo "Published synapse-broker and synapse at ${VERSION}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,53 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*.*.*"
+
+jobs:
+  build-publish:
+    name: Build & publish to Gitea registry
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache cargo registry
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-release-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-release-
+            ${{ runner.os }}-cargo-
+
+      - name: Build release binaries
+        run: cargo build --release --bin synapse-broker --bin synapse
+
+      - name: Publish binaries to Gitea generic registry
+        env:
+          GITEA_URL: http://192.168.0.12:30008
+          GITEA_TOKEN: ${{ secrets.LEXCODE_TOKEN }}
+          TAG: ${{ github.ref_name }}
+        run: |
+          VERSION="${TAG#v}"
+          REGISTRY="${GITEA_URL}/api/packages/StellarFleetOps/generic"
+
+          for BINARY in synapse-broker synapse; do
+            echo "Publishing ${BINARY} ${VERSION}..."
+            curl -sf -X PUT \
+              -H "Authorization: token ${GITEA_TOKEN}" \
+              -H "Content-Type: application/octet-stream" \
+              --data-binary "@target/release/${BINARY}" \
+              "${REGISTRY}/${BINARY}/${VERSION}/${BINARY}-linux-amd64"
+          done
+
+          echo "Published synapse-broker and synapse at ${VERSION}"


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/release.yml` — triggers on `v*.*.*` tags, builds `synapse-broker` and `synapse` binaries via GitHub Actions and publishes them to the Gitea generic package registry using `LEXCODE_TOKEN`
- Adds `.gitea/workflows/release.yml` — same trigger and publish logic, designed to run on the Gitea mirror via `lex-fleet-runner`; installs Rust via rustup (runner base image is `node:20-bullseye`), uses `FLEET_TOKEN` org secret

Both workflows publish to:
```
http://192.168.0.12:30008/api/packages/StellarFleetOps/generic/<binary>/<version>/<binary>-linux-amd64
```

The `.gitea/workflows/release.yml` will be picked up by the Gitea mirror of this repo (`StellarFleetOps/synapse`) when the mirror syncs, allowing Gitea Actions to build and publish independently of GitHub.

## Test plan

- [ ] Merge and tag `v0.5.0` (or next release) to trigger both workflows
- [ ] Verify `synapse-broker` and `synapse` appear in the Gitea generic package registry under `StellarFleetOps`
- [ ] Confirm GitHub Actions run completes successfully
- [ ] Confirm Gitea Actions run completes successfully on the mirror

## Summary by Sourcery

Add automated release workflows to build and publish binaries on version tags for both GitHub and Gitea.

CI:
- Introduce GitHub Actions workflow that builds synapse-broker and synapse on version tags and publishes artifacts to the Gitea generic package registry.
- Add Gitea Actions workflow to mirror the GitHub release process, building synapse-broker and synapse on version tags and publishing them to the same Gitea generic package registry.